### PR TITLE
horde-d69

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,13 @@ Run `horde docs env` for more detail on token setup and security.
 
 ## Usage
 
+All commands require a provider. For local Docker mode, pass `--provider docker`. Omit the flag when the `@horde/cdk` construct is deployed (auto-detects via SSM).
+
 ```bash
 # Launch a run
-horde launch PROJ-123
-horde launch PROJ-123 --branch feature/xyz
-horde launch PROJ-123 --workflow bugfix --timeout 30m
+horde launch --provider docker PROJ-123
+horde launch --provider docker PROJ-123 --branch feature/xyz
+horde launch --provider docker PROJ-123 --workflow bugfix --timeout 30m
 
 # Monitor
 horde status <run-id>

--- a/cmd/horde/factory.go
+++ b/cmd/horde/factory.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	"github.com/jorge-barreto/horde/internal/awscfg"
+	"github.com/jorge-barreto/horde/internal/config"
+	"github.com/jorge-barreto/horde/internal/provider"
+	"github.com/jorge-barreto/horde/internal/store"
+)
+
+type factoryDeps struct {
+	loadAWSConfig func(ctx context.Context, profile string) (aws.Config, error)
+	newSSMClient  func(cfg aws.Config) config.SSMClient
+	openStore     func(providerName string) (store.Store, func(), error)
+}
+
+func defaultFactoryDeps() factoryDeps {
+	return factoryDeps{
+		loadAWSConfig: awscfg.Load,
+		newSSMClient:  func(cfg aws.Config) config.SSMClient { return ssm.NewFromConfig(cfg) },
+		openStore:     openStore,
+	}
+}
+
+func openStore(providerName string) (store.Store, func(), error) {
+	switch providerName {
+	case "docker":
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return nil, nil, fmt.Errorf("getting home directory: %w", err)
+		}
+		dbPath := filepath.Join(homeDir, ".horde", "horde.db")
+		st, err := store.NewSQLiteStore(dbPath)
+		if err != nil {
+			return nil, nil, fmt.Errorf("opening store: %w", err)
+		}
+		return st, func() { st.Close() }, nil
+	case "aws-ecs":
+		return nil, nil, fmt.Errorf("aws-ecs store is not yet implemented")
+	default:
+		return nil, nil, fmt.Errorf("openStore: unsupported provider %q", providerName)
+	}
+}
+
+func initProviderAndStoreWith(ctx context.Context, name, profile string, deps factoryDeps) (provider.Provider, store.Store, func(), error) {
+	switch name {
+	case "docker":
+		prov := provider.NewDockerProvider()
+		st, cleanup, err := deps.openStore("docker")
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		return prov, st, cleanup, nil
+	case "aws-ecs":
+		awsCfg, err := deps.loadAWSConfig(ctx, profile)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("initializing aws-ecs provider: %w", err)
+		}
+		ssmClient := deps.newSSMClient(awsCfg)
+		if _, err := config.LoadFromSSM(ctx, ssmClient, config.DefaultSSMPath); err != nil {
+			return nil, nil, nil, fmt.Errorf("initializing aws-ecs provider: %s", config.Diagnostic(err))
+		}
+		return nil, nil, nil, fmt.Errorf("aws-ecs provider is not yet implemented")
+	case "":
+		awsCfg, err := deps.loadAWSConfig(ctx, profile)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("auto-detecting provider: %w\nhint: use --provider docker for local mode", err)
+		}
+		ssmClient := deps.newSSMClient(awsCfg)
+		if _, err := config.LoadFromSSM(ctx, ssmClient, config.DefaultSSMPath); err != nil {
+			return nil, nil, nil, fmt.Errorf("auto-detecting provider: %s\nhint: use --provider docker for local mode", config.Diagnostic(err))
+		}
+		return nil, nil, nil, fmt.Errorf("aws-ecs provider is not yet implemented")
+	default:
+		return nil, nil, nil, fmt.Errorf("unsupported provider %q: valid values are \"docker\" and \"aws-ecs\"", name)
+	}
+}

--- a/cmd/horde/factory_test.go
+++ b/cmd/horde/factory_test.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	smithy "github.com/aws/smithy-go"
+	"github.com/jorge-barreto/horde/internal/config"
+	"github.com/jorge-barreto/horde/internal/provider"
+	"github.com/jorge-barreto/horde/internal/store"
+)
+
+type stubStore struct{}
+
+func (s *stubStore) CreateRun(_ context.Context, _ *store.Run) error                 { return nil }
+func (s *stubStore) GetRun(_ context.Context, _ string) (*store.Run, error)          { return nil, nil }
+func (s *stubStore) UpdateRun(_ context.Context, _ string, _ *store.RunUpdate) error { return nil }
+func (s *stubStore) ListByRepo(_ context.Context, _ string, _ bool) ([]*store.Run, error) {
+	return nil, nil
+}
+func (s *stubStore) FindActiveByTicket(_ context.Context, _ string, _ string) ([]*store.Run, error) {
+	return nil, nil
+}
+func (s *stubStore) CountActive(_ context.Context) (int, error) { return 0, nil }
+
+type fakeSSMClient struct {
+	output *ssm.GetParameterOutput
+	err    error
+}
+
+func (f *fakeSSMClient) GetParameter(_ context.Context, _ *ssm.GetParameterInput, _ ...func(*ssm.Options)) (*ssm.GetParameterOutput, error) {
+	return f.output, f.err
+}
+
+func validSSMJSON() string {
+	return `{"cluster_arn":"arn:aws:ecs:us-east-1:123456789012:cluster/horde","task_definition_arn":"arn:aws:ecs:us-east-1:123456789012:task-definition/horde-worker:1","subnets":["subnet-abc","subnet-def"],"security_group":"sg-123","log_group":"/ecs/horde-worker","artifacts_bucket":"my-horde-artifacts","runs_table":"horde-runs","max_concurrent":5,"default_timeout_minutes":60}`
+}
+
+func TestInitProviderAndStore(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		provName    string
+		deps        factoryDeps
+		wantErr     bool
+		errContains []string
+	}{
+		{
+			name:     "explicit docker",
+			provName: "docker",
+			deps: factoryDeps{
+				openStore: func(_ string) (store.Store, func(), error) {
+					return &stubStore{}, func() {}, nil
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:     "explicit aws-ecs no-creds",
+			provName: "aws-ecs",
+			deps: factoryDeps{
+				loadAWSConfig: func(_ context.Context, _ string) (aws.Config, error) {
+					return aws.Config{}, fmt.Errorf("no valid credential sources")
+				},
+			},
+			wantErr:     true,
+			errContains: []string{"initializing aws-ecs provider"},
+		},
+		{
+			name:     "default SSM ok",
+			provName: "",
+			deps: factoryDeps{
+				loadAWSConfig: func(_ context.Context, _ string) (aws.Config, error) {
+					return aws.Config{}, nil
+				},
+				newSSMClient: func(_ aws.Config) config.SSMClient {
+					return &fakeSSMClient{
+						output: &ssm.GetParameterOutput{
+							Parameter: &ssmtypes.Parameter{Value: aws.String(validSSMJSON())},
+						},
+					}
+				},
+			},
+			wantErr:     true,
+			errContains: []string{"aws-ecs provider is not yet implemented"},
+		},
+		{
+			name:     "default SSM missing",
+			provName: "",
+			deps: factoryDeps{
+				loadAWSConfig: func(_ context.Context, _ string) (aws.Config, error) {
+					return aws.Config{}, nil
+				},
+				newSSMClient: func(_ aws.Config) config.SSMClient {
+					return &fakeSSMClient{
+						err: &ssmtypes.ParameterNotFound{Message: aws.String("not found")},
+					}
+				},
+			},
+			wantErr:     true,
+			errContains: []string{"auto-detecting provider", "deploy the @horde/cdk construct"},
+		},
+		{
+			name:     "default SSM access denied",
+			provName: "",
+			deps: factoryDeps{
+				loadAWSConfig: func(_ context.Context, _ string) (aws.Config, error) {
+					return aws.Config{}, nil
+				},
+				newSSMClient: func(_ aws.Config) config.SSMClient {
+					return &fakeSSMClient{
+						err: &smithy.GenericAPIError{Code: "AccessDeniedException", Message: "not authorized"},
+					}
+				},
+			},
+			wantErr:     true,
+			errContains: []string{"auto-detecting provider", "attach the horde CLI user managed policy"},
+		},
+		{
+			name:        "unsupported provider",
+			provName:    "gcp",
+			deps:        factoryDeps{},
+			wantErr:     true,
+			errContains: []string{`unsupported provider "gcp"`},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			prov, st, cleanup, err := initProviderAndStoreWith(context.Background(), tc.provName, "", tc.deps)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				for _, sub := range tc.errContains {
+					if !strings.Contains(err.Error(), sub) {
+						t.Errorf("error %q does not contain %q", err.Error(), sub)
+					}
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tc.provName == "docker" {
+				if _, ok := prov.(*provider.DockerProvider); !ok {
+					t.Errorf("expected *provider.DockerProvider, got %T", prov)
+				}
+				if st == nil {
+					t.Error("expected non-nil store")
+				}
+				if cleanup == nil {
+					t.Error("expected non-nil cleanup")
+				}
+				cleanup()
+			}
+		})
+	}
+}

--- a/cmd/horde/main.go
+++ b/cmd/horde/main.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	horde "github.com/jorge-barreto/horde"
 	"github.com/jorge-barreto/horde/internal/awscfg"
 	"github.com/jorge-barreto/horde/internal/config"
@@ -1188,5 +1189,68 @@ func resolveLaunchedBy(ctx context.Context, providerName string, cwd string, aws
 		return arn, nil
 	default:
 		return "", fmt.Errorf("resolving launched_by: unsupported provider %q", providerName)
+	}
+}
+
+// initProviderAndStore creates the Provider and Store based on the --provider flag.
+// Selection rule: "docker" → DockerProvider + SQLite; "aws-ecs" → ECS + DynamoDB
+// (not yet implemented); "" → auto-detect via SSM.
+// Returns a cleanup function that must be deferred to release store resources.
+func initProviderAndStore(ctx context.Context, cmd *cli.Command) (provider.Provider, store.Store, func(), error) {
+	name := cmd.String("provider")
+	profile := cmd.String("profile")
+
+	switch name {
+	case "docker":
+		prov := provider.NewDockerProvider()
+		st, cleanup, err := openStore("docker")
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		return prov, st, cleanup, nil
+	case "aws-ecs":
+		awsCfg, err := awscfg.Load(ctx, profile)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("initializing aws-ecs provider: %w", err)
+		}
+		ssmClient := ssm.NewFromConfig(awsCfg)
+		if _, err := config.LoadFromSSM(ctx, ssmClient, config.DefaultSSMPath); err != nil {
+			return nil, nil, nil, fmt.Errorf("initializing aws-ecs provider: %s", config.Diagnostic(err))
+		}
+		return nil, nil, nil, fmt.Errorf("aws-ecs provider is not yet implemented")
+	case "":
+		awsCfg, err := awscfg.Load(ctx, profile)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("auto-detecting provider: %w\nhint: use --provider docker for local mode", err)
+		}
+		ssmClient := ssm.NewFromConfig(awsCfg)
+		if _, err := config.LoadFromSSM(ctx, ssmClient, config.DefaultSSMPath); err != nil {
+			return nil, nil, nil, fmt.Errorf("auto-detecting provider: %s\nhint: use --provider docker for local mode", config.Diagnostic(err))
+		}
+		return nil, nil, nil, fmt.Errorf("aws-ecs provider is not yet implemented")
+	default:
+		return nil, nil, nil, fmt.Errorf("unsupported provider %q: valid values are \"docker\" and \"aws-ecs\"", name)
+	}
+}
+
+// openStore creates the Store for the given provider name.
+// Returns a cleanup function that must be deferred to release resources.
+func openStore(providerName string) (store.Store, func(), error) {
+	switch providerName {
+	case "docker":
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return nil, nil, fmt.Errorf("getting home directory: %w", err)
+		}
+		dbPath := filepath.Join(homeDir, ".horde", "horde.db")
+		st, err := store.NewSQLiteStore(dbPath)
+		if err != nil {
+			return nil, nil, fmt.Errorf("opening store: %w", err)
+		}
+		return st, func() { st.Close() }, nil
+	case "aws-ecs":
+		return nil, nil, fmt.Errorf("aws-ecs store is not yet implemented")
+	default:
+		return nil, nil, fmt.Errorf("openStore: unsupported provider %q", providerName)
 	}
 }

--- a/cmd/horde/main.go
+++ b/cmd/horde/main.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	horde "github.com/jorge-barreto/horde"
 	"github.com/jorge-barreto/horde/internal/awscfg"
 	"github.com/jorge-barreto/horde/internal/config"
@@ -1216,60 +1215,5 @@ func resolveLaunchedBy(ctx context.Context, providerName string, cwd string, aws
 // (not yet implemented); "" → auto-detect via SSM.
 // Returns a cleanup function that must be deferred to release store resources.
 func initProviderAndStore(ctx context.Context, cmd *cli.Command) (provider.Provider, store.Store, func(), error) {
-	name := cmd.String("provider")
-	profile := cmd.String("profile")
-
-	switch name {
-	case "docker":
-		prov := provider.NewDockerProvider()
-		st, cleanup, err := openStore("docker")
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		return prov, st, cleanup, nil
-	case "aws-ecs":
-		awsCfg, err := awscfg.Load(ctx, profile)
-		if err != nil {
-			return nil, nil, nil, fmt.Errorf("initializing aws-ecs provider: %w", err)
-		}
-		ssmClient := ssm.NewFromConfig(awsCfg)
-		if _, err := config.LoadFromSSM(ctx, ssmClient, config.DefaultSSMPath); err != nil {
-			return nil, nil, nil, fmt.Errorf("initializing aws-ecs provider: %s", config.Diagnostic(err))
-		}
-		return nil, nil, nil, fmt.Errorf("aws-ecs provider is not yet implemented")
-	case "":
-		awsCfg, err := awscfg.Load(ctx, profile)
-		if err != nil {
-			return nil, nil, nil, fmt.Errorf("auto-detecting provider: %w\nhint: use --provider docker for local mode", err)
-		}
-		ssmClient := ssm.NewFromConfig(awsCfg)
-		if _, err := config.LoadFromSSM(ctx, ssmClient, config.DefaultSSMPath); err != nil {
-			return nil, nil, nil, fmt.Errorf("auto-detecting provider: %s\nhint: use --provider docker for local mode", config.Diagnostic(err))
-		}
-		return nil, nil, nil, fmt.Errorf("aws-ecs provider is not yet implemented")
-	default:
-		return nil, nil, nil, fmt.Errorf("unsupported provider %q: valid values are \"docker\" and \"aws-ecs\"", name)
-	}
-}
-
-// openStore creates the Store for the given provider name.
-// Returns a cleanup function that must be deferred to release resources.
-func openStore(providerName string) (store.Store, func(), error) {
-	switch providerName {
-	case "docker":
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			return nil, nil, fmt.Errorf("getting home directory: %w", err)
-		}
-		dbPath := filepath.Join(homeDir, ".horde", "horde.db")
-		st, err := store.NewSQLiteStore(dbPath)
-		if err != nil {
-			return nil, nil, fmt.Errorf("opening store: %w", err)
-		}
-		return st, func() { st.Close() }, nil
-	case "aws-ecs":
-		return nil, nil, fmt.Errorf("aws-ecs store is not yet implemented")
-	default:
-		return nil, nil, fmt.Errorf("openStore: unsupported provider %q", providerName)
-	}
+	return initProviderAndStoreWith(ctx, cmd.String("provider"), cmd.String("profile"), defaultFactoryDeps())
 }

--- a/cmd/horde/main.go
+++ b/cmd/horde/main.go
@@ -37,28 +37,20 @@ func newApp() *cli.Command {
 	return &cli.Command{
 		Name:  "horde",
 		Usage: "Cloud launcher for orc workflows",
-		Description: `horde runs orc workflows on ephemeral Docker containers (or ECS Fargate
-in v0.2). It clones a repo, runs orc, collects results, and tears down.
+		Description: `horde runs orc workflows on ephemeral containers (Docker locally,
+ECS Fargate in AWS). It clones a repo, runs orc, collects results, and tears down.
 
 horde must be run from inside a git repository — the repo URL is inferred
 from the local git remote. Run 'horde docs' for detailed documentation.`,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "provider",
-				Value: "docker",
-				Usage: "Override provider selection (docker or aws-ecs)",
+				Usage: "Provider (docker or aws-ecs); omit for auto-detection via SSM",
 			},
 			&cli.StringFlag{
 				Name:  "profile",
 				Usage: "AWS named profile (passed through to AWS SDK)",
 			},
-		},
-		Before: func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
-			p := cmd.String("provider")
-			if p != "docker" {
-				return ctx, fmt.Errorf("unsupported provider %q: only \"docker\" is supported in v0.1", p)
-			}
-			return ctx, nil
 		},
 		Commands: []*cli.Command{
 			launchCmd(),
@@ -114,6 +106,18 @@ ticket is already active.`,
 			timeout := cmd.Duration("timeout")
 			force := cmd.Bool("force")
 
+			prov, st, cleanup, err := initProviderAndStore(ctx, cmd)
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+
+			provName := cmd.String("provider")
+			if provName == "" {
+				// TODO(d69): when auto-detect succeeds, resolve actual provider name.
+				provName = "docker"
+			}
+
 			cwd, err := os.Getwd()
 			if err != nil {
 				return fmt.Errorf("getting working directory: %w", err)
@@ -134,21 +138,10 @@ ticket is already active.`,
 				return err
 			}
 
-			launchedBy, err := resolveLaunchedBy(ctx, cmd.String("provider"), cwd, nil, cmd.String("profile"))
+			launchedBy, err := resolveLaunchedBy(ctx, provName, cwd, nil, cmd.String("profile"))
 			if err != nil {
 				return err
 			}
-
-			homeDir, err := os.UserHomeDir()
-			if err != nil {
-				return fmt.Errorf("getting home directory: %w", err)
-			}
-			dbPath := filepath.Join(homeDir, ".horde", "horde.db")
-			st, err := store.NewSQLiteStore(dbPath)
-			if err != nil {
-				return err
-			}
-			defer st.Close()
 
 			active, err := st.FindActiveByTicket(ctx, repo, ticket)
 			if err != nil {
@@ -166,7 +159,7 @@ ticket is already active.`,
 				Ticket:     ticket,
 				Branch:     branch,
 				Workflow:   workflow,
-				Provider:   "docker",
+				Provider:   provName,
 				Status:     store.StatusPending,
 				LaunchedBy: launchedBy,
 				StartedAt:  now,
@@ -176,13 +169,16 @@ ticket is already active.`,
 				return fmt.Errorf("recording run: %w", err)
 			}
 
-			prov := provider.NewDockerProvider()
+			dp, ok := prov.(*provider.DockerProvider)
+			if !ok {
+				return fmt.Errorf("image build is only supported for the docker provider")
+			}
 
 			workerFS, err := fs.Sub(horde.WorkerFiles, "docker")
 			if err != nil {
 				return fmt.Errorf("accessing worker files: %w", err)
 			}
-			if err := prov.EnsureImage(ctx, workerFS, cwd, os.Stderr); err != nil {
+			if err := dp.EnsureImage(ctx, workerFS, cwd, os.Stderr); err != nil {
 				failedStatus := store.StatusFailed
 				now := time.Now()
 				if updateErr := st.UpdateRun(ctx, id, &store.RunUpdate{Status: &failedStatus, CompletedAt: &now}); updateErr != nil {
@@ -252,16 +248,16 @@ The entrypoint re-runs and orc picks up from where it left off. Use
 			}
 			timeout := cmd.Duration("timeout")
 
+			prov, st, cleanup, err := initProviderAndStore(ctx, cmd)
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+
 			homeDir, err := os.UserHomeDir()
 			if err != nil {
 				return fmt.Errorf("getting home directory: %w", err)
 			}
-			dbPath := filepath.Join(homeDir, ".horde", "horde.db")
-			st, err := store.NewSQLiteStore(dbPath)
-			if err != nil {
-				return err
-			}
-			defer st.Close()
 
 			run, err := st.GetRun(ctx, runID)
 			if err != nil {
@@ -271,9 +267,10 @@ The entrypoint re-runs and orc picks up from where it left off. Use
 				return fmt.Errorf("reading run: %w", err)
 			}
 
-			prov := provider.NewDockerProvider()
-			if err := handleLazyCheck(ctx, prov, st, run, homeDir); err != nil {
-				return err
+			if dp, ok := prov.(*provider.DockerProvider); ok {
+				if err := handleLazyCheck(ctx, dp, st, run, homeDir); err != nil {
+					return err
+				}
 			}
 
 			if run.Status == store.StatusPending {
@@ -299,7 +296,11 @@ The entrypoint re-runs and orc picks up from where it left off. Use
 			}
 
 			// Clear previous completion marker and exec orc inside the running container
-			prov.ExecInContainer(ctx, run.InstanceID, "rm -f /workspace/.horde-exit-code")
+			dp, ok := prov.(*provider.DockerProvider)
+			if !ok {
+				return fmt.Errorf("retry is only supported for the docker provider")
+			}
+			dp.ExecInContainer(ctx, run.InstanceID, "rm -f /workspace/.horde-exit-code")
 
 			ticket := run.Ticket
 			orcCmd := "cd /workspace && orc run " + ticket + " --auto --no-color; echo $? > /workspace/.horde-exit-code"
@@ -344,16 +345,18 @@ result collection.`,
 			if runID == "" {
 				return fmt.Errorf("missing required argument: <run-id>")
 			}
+
+			prov, st, cleanup, err := initProviderAndStore(ctx, cmd)
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+
 			homeDir, err := os.UserHomeDir()
 			if err != nil {
 				return fmt.Errorf("getting home directory: %w", err)
 			}
-			dbPath := filepath.Join(homeDir, ".horde", "horde.db")
-			st, err := store.NewSQLiteStore(dbPath)
-			if err != nil {
-				return fmt.Errorf("opening store: %w", err)
-			}
-			defer st.Close()
+
 			run, err := st.GetRun(ctx, runID)
 			if err != nil {
 				if errors.Is(err, store.ErrRunNotFound) {
@@ -361,12 +364,15 @@ result collection.`,
 				}
 				return fmt.Errorf("reading run: %w", err)
 			}
-			prov := provider.NewDockerProvider()
-			if err := handleLazyCheck(ctx, prov, st, run, homeDir); err != nil {
-				return err
+			if dp, ok := prov.(*provider.DockerProvider); ok {
+				if err := handleLazyCheck(ctx, dp, st, run, homeDir); err != nil {
+					return err
+				}
 			}
 			if run.TotalCostUSD == nil && (run.Status == store.StatusRunning || run.Status == store.StatusPending) {
-				run.TotalCostUSD = fetchLiveCost(ctx, prov, run)
+				if dp, ok := prov.(*provider.DockerProvider); ok {
+					run.TotalCostUSD = fetchLiveCost(ctx, dp, run)
+				}
 			}
 			printRunStatus(run)
 			return nil
@@ -394,16 +400,18 @@ removed, falls back to the saved container.log in the results directory.`,
 				return fmt.Errorf("missing required argument: <run-id>")
 			}
 			follow := cmd.Bool("follow")
+
+			prov, st, cleanup, err := initProviderAndStore(ctx, cmd)
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+
 			homeDir, err := os.UserHomeDir()
 			if err != nil {
 				return fmt.Errorf("getting home directory: %w", err)
 			}
-			dbPath := filepath.Join(homeDir, ".horde", "horde.db")
-			st, err := store.NewSQLiteStore(dbPath)
-			if err != nil {
-				return fmt.Errorf("opening store: %w", err)
-			}
-			defer st.Close()
+
 			run, err := st.GetRun(ctx, runID)
 			if err != nil {
 				if errors.Is(err, store.ErrRunNotFound) {
@@ -423,7 +431,6 @@ removed, falls back to the saved container.log in the results directory.`,
 			if run.InstanceID == "" {
 				return fmt.Errorf("logs unavailable: run %s has no container yet", runID)
 			}
-			prov := provider.NewDockerProvider()
 			reader, err := prov.Logs(ctx, run.InstanceID, follow)
 			if err != nil {
 				return fmt.Errorf("reading logs: %w", err)
@@ -450,16 +457,18 @@ for 'horde retry' or 'horde shell'. Use 'horde clean' to remove it.`,
 			if runID == "" {
 				return fmt.Errorf("missing required argument: <run-id>")
 			}
+
+			prov, st, cleanup, err := initProviderAndStore(ctx, cmd)
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+
 			homeDir, err := os.UserHomeDir()
 			if err != nil {
 				return fmt.Errorf("getting home directory: %w", err)
 			}
-			dbPath := filepath.Join(homeDir, ".horde", "horde.db")
-			st, err := store.NewSQLiteStore(dbPath)
-			if err != nil {
-				return fmt.Errorf("opening store: %w", err)
-			}
-			defer st.Close()
+
 			run, err := st.GetRun(ctx, runID)
 			if err != nil {
 				if errors.Is(err, store.ErrRunNotFound) {
@@ -467,9 +476,10 @@ for 'horde retry' or 'horde shell'. Use 'horde clean' to remove it.`,
 				}
 				return fmt.Errorf("reading run: %w", err)
 			}
-			prov := provider.NewDockerProvider()
-			if err := handleLazyCheck(ctx, prov, st, run, homeDir); err != nil {
-				return err
+			if dp, ok := prov.(*provider.DockerProvider); ok {
+				if err := handleLazyCheck(ctx, dp, st, run, homeDir); err != nil {
+					return err
+				}
 			}
 			if run.Status != store.StatusPending && run.Status != store.StatusRunning {
 				return fmt.Errorf("run %s is already %s", runID, run.Status)
@@ -539,16 +549,18 @@ information if the result file is missing (e.g., orc crashed early).`,
 			if runID == "" {
 				return fmt.Errorf("missing required argument: <run-id>")
 			}
+
+			prov, st, cleanup, err := initProviderAndStore(ctx, cmd)
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+
 			homeDir, err := os.UserHomeDir()
 			if err != nil {
 				return fmt.Errorf("getting home directory: %w", err)
 			}
-			dbPath := filepath.Join(homeDir, ".horde", "horde.db")
-			st, err := store.NewSQLiteStore(dbPath)
-			if err != nil {
-				return fmt.Errorf("opening store: %w", err)
-			}
-			defer st.Close()
+
 			run, err := st.GetRun(ctx, runID)
 			if err != nil {
 				if errors.Is(err, store.ErrRunNotFound) {
@@ -556,9 +568,10 @@ information if the result file is missing (e.g., orc crashed early).`,
 				}
 				return fmt.Errorf("reading run: %w", err)
 			}
-			prov := provider.NewDockerProvider()
-			if err := handleLazyCheck(ctx, prov, st, run, homeDir); err != nil {
-				return err
+			if dp, ok := prov.(*provider.DockerProvider); ok {
+				if err := handleLazyCheck(ctx, dp, st, run, homeDir); err != nil {
+					return err
+				}
 			}
 			if run.Status == store.StatusPending || run.Status == store.StatusRunning {
 				fmt.Printf("Run %s is still in progress (status: %s)\n", run.ID, run.Status)
@@ -607,6 +620,17 @@ include completed, failed, and killed runs.`,
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			all := cmd.Bool("all")
 
+			prov, st, cleanup, err := initProviderAndStore(ctx, cmd)
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+
+			homeDir, err := os.UserHomeDir()
+			if err != nil {
+				return fmt.Errorf("getting home directory: %w", err)
+			}
+
 			cwd, err := os.Getwd()
 			if err != nil {
 				return fmt.Errorf("getting working directory: %w", err)
@@ -617,30 +641,21 @@ include completed, failed, and killed runs.`,
 				return err
 			}
 
-			homeDir, err := os.UserHomeDir()
-			if err != nil {
-				return fmt.Errorf("getting home directory: %w", err)
-			}
-			dbPath := filepath.Join(homeDir, ".horde", "horde.db")
-			st, err := store.NewSQLiteStore(dbPath)
-			if err != nil {
-				return err
-			}
-			defer st.Close()
-
 			runs, err := st.ListByRepo(ctx, repo, !all)
 			if err != nil {
 				return fmt.Errorf("listing runs: %w", err)
 			}
 
-			prov := provider.NewDockerProvider()
+			dp, _ := prov.(*provider.DockerProvider)
 			for _, run := range runs {
-				if err := handleLazyCheck(ctx, prov, st, run, homeDir); err != nil {
-					fmt.Fprintf(os.Stderr, "warning: checking run %s: %v\n", run.ID, err)
-					continue
-				}
-				if run.TotalCostUSD == nil && (run.Status == store.StatusRunning || run.Status == store.StatusPending) {
-					run.TotalCostUSD = fetchLiveCost(ctx, prov, run)
+				if dp != nil {
+					if err := handleLazyCheck(ctx, dp, st, run, homeDir); err != nil {
+						fmt.Fprintf(os.Stderr, "warning: checking run %s: %v\n", run.ID, err)
+						continue
+					}
+					if run.TotalCostUSD == nil && (run.Status == store.StatusRunning || run.Status == store.StatusPending) {
+						run.TotalCostUSD = fetchLiveCost(ctx, dp, run)
+					}
 				}
 			}
 
@@ -694,18 +709,12 @@ func cleanCmd() *cli.Command {
 containers for all terminal runs (success, failed, killed). With a run ID,
 removes only that run's container. Does not affect running or pending runs.`,
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			homeDir, err := os.UserHomeDir()
+			prov, st, cleanup, err := initProviderAndStore(ctx, cmd)
 			if err != nil {
-				return fmt.Errorf("getting home directory: %w", err)
+				return err
 			}
-			dbPath := filepath.Join(homeDir, ".horde", "horde.db")
-			st, err := store.NewSQLiteStore(dbPath)
-			if err != nil {
-				return fmt.Errorf("opening store: %w", err)
-			}
-			defer st.Close()
+			defer cleanup()
 
-			prov := provider.NewDockerProvider()
 			runID := cmd.Args().First()
 
 			if runID != "" {
@@ -724,10 +733,12 @@ removes only that run's container. Does not affect running or pending runs.`,
 					fmt.Printf("Run %s has no container\n", runID)
 					return nil
 				}
-				if err := prov.RemoveContainer(ctx, run.InstanceID); err != nil {
-					fmt.Fprintf(os.Stderr, "warning: %v\n", err)
-				} else {
-					fmt.Printf("Removed container for run %s\n", runID)
+				if dp, ok := prov.(*provider.DockerProvider); ok {
+					if err := dp.RemoveContainer(ctx, run.InstanceID); err != nil {
+						fmt.Fprintf(os.Stderr, "warning: %v\n", err)
+					} else {
+						fmt.Printf("Removed container for run %s\n", runID)
+					}
 				}
 				return nil
 			}
@@ -760,8 +771,10 @@ removes only that run's container. Does not affect running or pending runs.`,
 				if activeIDs[r.ID] || r.InstanceID == "" {
 					continue
 				}
-				if err := prov.RemoveContainer(ctx, r.InstanceID); err == nil {
-					cleaned++
+				if dp, ok := prov.(*provider.DockerProvider); ok {
+					if err := dp.RemoveContainer(ctx, r.InstanceID); err == nil {
+						cleaned++
+					}
 				}
 			}
 			fmt.Printf("Removed %d container(s)\n", cleaned)
@@ -783,16 +796,17 @@ directly (e.g., 'orc run --resume'), or fix issues manually.`,
 			if runID == "" {
 				return fmt.Errorf("missing required argument: <run-id>")
 			}
+
+			prov, st, cleanup, err := initProviderAndStore(ctx, cmd)
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+
 			homeDir, err := os.UserHomeDir()
 			if err != nil {
 				return fmt.Errorf("getting home directory: %w", err)
 			}
-			dbPath := filepath.Join(homeDir, ".horde", "horde.db")
-			st, err := store.NewSQLiteStore(dbPath)
-			if err != nil {
-				return fmt.Errorf("opening store: %w", err)
-			}
-			defer st.Close()
 
 			run, err := st.GetRun(ctx, runID)
 			if err != nil {
@@ -802,9 +816,10 @@ directly (e.g., 'orc run --resume'), or fix issues manually.`,
 				return fmt.Errorf("reading run: %w", err)
 			}
 
-			prov := provider.NewDockerProvider()
-			if err := handleLazyCheck(ctx, prov, st, run, homeDir); err != nil {
-				return err
+			if dp, ok := prov.(*provider.DockerProvider); ok {
+				if err := handleLazyCheck(ctx, dp, st, run, homeDir); err != nil {
+					return err
+				}
 			}
 
 			if run.InstanceID == "" {
@@ -819,6 +834,10 @@ directly (e.g., 'orc run --resume'), or fix issues manually.`,
 			}
 			if instStatus.State != "running" {
 				return fmt.Errorf("container for run %s is not running — use 'horde retry' first", runID)
+			}
+
+			if _, ok := prov.(*provider.DockerProvider); !ok {
+				return fmt.Errorf("shell is only supported for the docker provider")
 			}
 
 			// Exec into the running container

--- a/cmd/horde/main_test.go
+++ b/cmd/horde/main_test.go
@@ -86,7 +86,7 @@ func TestLaunch_Success(t *testing.T) {
 	os.Stdout = pw
 	defer func() { os.Stdout = origStdout }()
 
-	err = newApp().Run(ctx, []string{"horde", "launch", "TICKET-1"})
+	err = newApp().Run(ctx, []string{"horde", "--provider", "docker", "launch", "TICKET-1"})
 
 	pw.Close()
 	os.Stdout = origStdout
@@ -156,7 +156,7 @@ func TestLaunch_WithFlags(t *testing.T) {
 	os.Stdout = pw
 	defer func() { os.Stdout = origStdout }()
 
-	err = newApp().Run(ctx, []string{"horde", "launch", "--branch", "feature-x", "--workflow", "review", "--timeout", "30m", "TICKET-2"})
+	err = newApp().Run(ctx, []string{"horde", "--provider", "docker", "launch", "--branch", "feature-x", "--workflow", "review", "--timeout", "30m", "TICKET-2"})
 
 	pw.Close()
 	os.Stdout = origStdout
@@ -197,7 +197,7 @@ func TestLaunch_MissingTicket(t *testing.T) {
 	_ = setupLaunchEnv(t)
 	ctx := context.Background()
 
-	err := newApp().Run(ctx, []string{"horde", "launch"})
+	err := newApp().Run(ctx, []string{"horde", "--provider", "docker", "launch"})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -221,7 +221,7 @@ func TestLaunch_NotGitRepo(t *testing.T) {
 	t.Cleanup(func() { os.Chdir(oldDir) })
 
 	ctx := context.Background()
-	err := newApp().Run(ctx, []string{"horde", "launch", "TICKET-1"})
+	err := newApp().Run(ctx, []string{"horde", "--provider", "docker", "launch", "TICKET-1"})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -257,7 +257,7 @@ func TestLaunch_MissingEnvFile(t *testing.T) {
 	t.Cleanup(func() { os.Chdir(oldDir) })
 
 	ctx := context.Background()
-	err := newApp().Run(ctx, []string{"horde", "launch", "TICKET-1"})
+	err := newApp().Run(ctx, []string{"horde", "--provider", "docker", "launch", "TICKET-1"})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -294,7 +294,7 @@ func TestLaunch_MissingEnvKey(t *testing.T) {
 	t.Cleanup(func() { os.Chdir(oldDir) })
 
 	ctx := context.Background()
-	err := newApp().Run(ctx, []string{"horde", "launch", "TICKET-1"})
+	err := newApp().Run(ctx, []string{"horde", "--provider", "docker", "launch", "TICKET-1"})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -328,7 +328,7 @@ func TestLaunch_DuplicateTicket_NoForce(t *testing.T) {
 	}
 	st.Close()
 
-	err = newApp().Run(ctx, []string{"horde", "launch", "TICKET-1"})
+	err = newApp().Run(ctx, []string{"horde", "--provider", "docker", "launch", "TICKET-1"})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -384,7 +384,7 @@ func TestLaunch_DuplicateTicket_WithForce(t *testing.T) {
 	os.Stdout = pw
 	defer func() { os.Stdout = origStdout }()
 
-	err = newApp().Run(ctx, []string{"horde", "launch", "--force", "TICKET-1"})
+	err = newApp().Run(ctx, []string{"horde", "--provider", "docker", "launch", "--force", "TICKET-1"})
 
 	pw.Close()
 	os.Stdout = origStdout
@@ -429,7 +429,7 @@ func TestLaunch_DockerFailure(t *testing.T) {
 
 	os.WriteFile(filepath.Join(env.binDir, "docker"), []byte("#!/bin/sh\ncase \"$1\" in\n  image) echo \"2099-01-01T00:00:00Z\";;\n  tag) exit 0;;\n  *) echo \"Error: Cannot connect to the Docker daemon\" >&2; exit 1;;\nesac\n"), 0o755)
 
-	err := newApp().Run(ctx, []string{"horde", "launch", "TICKET-1"})
+	err := newApp().Run(ctx, []string{"horde", "--provider", "docker", "launch", "TICKET-1"})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -473,7 +473,7 @@ func TestLaunch_DockerFailure_NoStderrWarning(t *testing.T) {
 	os.Stderr = stderrW
 	defer func() { os.Stderr = origStderr }()
 
-	runErr := newApp().Run(ctx, []string{"horde", "launch", "TICKET-1"})
+	runErr := newApp().Run(ctx, []string{"horde", "--provider", "docker", "launch", "TICKET-1"})
 
 	stderrW.Close()
 	os.Stderr = origStderr
@@ -511,15 +511,15 @@ func TestLaunch_DockerFailure_NoStderrWarning(t *testing.T) {
 	}
 }
 
-func TestProvider_UnsupportedValue(t *testing.T) {
+func TestProvider_InvalidValue(t *testing.T) {
 	_ = setupLaunchEnv(t)
 	ctx := context.Background()
 
-	err := newApp().Run(ctx, []string{"horde", "--provider", "aws-ecs", "launch", "TICKET-1"})
+	err := newApp().Run(ctx, []string{"horde", "--provider", "gcp", "launch", "TICKET-1"})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
-	if !strings.Contains(err.Error(), `unsupported provider "aws-ecs"`) {
+	if !strings.Contains(err.Error(), `unsupported provider "gcp"`) {
 		t.Errorf("error %q does not contain expected message", err.Error())
 	}
 }
@@ -559,7 +559,7 @@ func TestProfile_AcceptedAsGlobalFlag(t *testing.T) {
 	os.Stdout = pw
 	defer func() { os.Stdout = origStdout }()
 
-	err = newApp().Run(ctx, []string{"horde", "--profile", "staging", "launch", "TICKET-1"})
+	err = newApp().Run(ctx, []string{"horde", "--provider", "docker", "--profile", "staging", "launch", "TICKET-1"})
 
 	pw.Close()
 	os.Stdout = origStdout
@@ -632,7 +632,7 @@ func TestStatus_CompletedRun(t *testing.T) {
 	}
 	os.Stdout = pw
 	defer func() { os.Stdout = origStdout }()
-	runErr := newApp().Run(ctx, []string{"horde", "status", runID})
+	runErr := newApp().Run(ctx, []string{"horde", "--provider", "docker", "status", runID})
 	pw.Close()
 	os.Stdout = origStdout
 	out, _ := io.ReadAll(pr)
@@ -700,7 +700,7 @@ esac
 	}
 	os.Stdout = pw
 	defer func() { os.Stdout = origStdout }()
-	runErr := newApp().Run(ctx, []string{"horde", "status", runID})
+	runErr := newApp().Run(ctx, []string{"horde", "--provider", "docker", "status", runID})
 	pw.Close()
 	os.Stdout = origStdout
 	out, _ := io.ReadAll(pr)
@@ -731,7 +731,7 @@ func TestStatus_NotFound(t *testing.T) {
 	}
 	st.Close()
 
-	err = newApp().Run(ctx, []string{"horde", "status", "nonexistent"})
+	err = newApp().Run(ctx, []string{"horde", "--provider", "docker", "status", "nonexistent"})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -744,7 +744,7 @@ func TestStatus_MissingRunID(t *testing.T) {
 	setupStatusEnv(t, "#!/bin/sh\n# no-op\n")
 	ctx := context.Background()
 
-	err := newApp().Run(ctx, []string{"horde", "status"})
+	err := newApp().Run(ctx, []string{"horde", "--provider", "docker", "status"})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -793,7 +793,7 @@ esac
 	}
 	os.Stdout = pw
 	defer func() { os.Stdout = origStdout }()
-	runErr := newApp().Run(ctx, []string{"horde", "status", runID})
+	runErr := newApp().Run(ctx, []string{"horde", "--provider", "docker", "status", runID})
 	pw.Close()
 	os.Stdout = origStdout
 	out, _ := io.ReadAll(pr)
@@ -874,7 +874,7 @@ esac
 	os.Stdout = pw
 	defer func() { os.Stdout = origStdout }()
 	before := time.Now()
-	runErr := newApp().Run(ctx, []string{"horde", "status", runID})
+	runErr := newApp().Run(ctx, []string{"horde", "--provider", "docker", "status", runID})
 	after := time.Now()
 	pw.Close()
 	os.Stdout = origStdout
@@ -964,7 +964,7 @@ esac
 	}
 	os.Stdout = pw
 	defer func() { os.Stdout = origStdout }()
-	runErr := newApp().Run(ctx, []string{"horde", "status", runID})
+	runErr := newApp().Run(ctx, []string{"horde", "--provider", "docker", "status", runID})
 	pw.Close()
 	os.Stdout = origStdout
 	out, _ := io.ReadAll(pr)
@@ -1037,7 +1037,7 @@ esac
 	}
 	os.Stdout = pw
 	defer func() { os.Stdout = origStdout }()
-	runErr := newApp().Run(ctx, []string{"horde", "status", runID})
+	runErr := newApp().Run(ctx, []string{"horde", "--provider", "docker", "status", runID})
 	pw.Close()
 	os.Stdout = origStdout
 	out, _ := io.ReadAll(pr)
@@ -1106,7 +1106,7 @@ esac
 	}
 	os.Stdout = pw
 	defer func() { os.Stdout = origStdout }()
-	runErr := newApp().Run(ctx, []string{"horde", "status", runID})
+	runErr := newApp().Run(ctx, []string{"horde", "--provider", "docker", "status", runID})
 	pw.Close()
 	os.Stdout = origStdout
 	out, _ := io.ReadAll(pr)
@@ -1199,7 +1199,7 @@ esac
 	os.Stdout = w
 	defer func() { os.Stdout = origStdout }()
 
-	runErr := newApp().Run(ctx, []string{"horde", "status", runID})
+	runErr := newApp().Run(ctx, []string{"horde", "--provider", "docker", "status", runID})
 
 	w.Close()
 	os.Stdout = origStdout
@@ -1267,7 +1267,7 @@ func TestList_ActiveOnly(t *testing.T) {
 	os.Stdout = pw
 	defer func() { os.Stdout = origStdout }()
 
-	runErr := newApp().Run(ctx, []string{"horde", "list"})
+	runErr := newApp().Run(ctx, []string{"horde", "--provider", "docker", "list"})
 
 	pw.Close()
 	os.Stdout = origStdout
@@ -1323,7 +1323,7 @@ func TestList_All(t *testing.T) {
 	os.Stdout = pw
 	defer func() { os.Stdout = origStdout }()
 
-	runErr := newApp().Run(ctx, []string{"horde", "list", "--all"})
+	runErr := newApp().Run(ctx, []string{"horde", "--provider", "docker", "list", "--all"})
 
 	pw.Close()
 	os.Stdout = origStdout
@@ -1363,7 +1363,7 @@ func TestList_EmptyResult(t *testing.T) {
 	os.Stdout = pw
 	defer func() { os.Stdout = origStdout }()
 
-	runErr := newApp().Run(ctx, []string{"horde", "list"})
+	runErr := newApp().Run(ctx, []string{"horde", "--provider", "docker", "list"})
 
 	pw.Close()
 	os.Stdout = origStdout
@@ -1396,7 +1396,7 @@ func TestList_EmptyResult_All(t *testing.T) {
 	os.Stdout = pw
 	defer func() { os.Stdout = origStdout }()
 
-	runErr := newApp().Run(ctx, []string{"horde", "list", "--all"})
+	runErr := newApp().Run(ctx, []string{"horde", "--provider", "docker", "list", "--all"})
 
 	pw.Close()
 	os.Stdout = origStdout
@@ -1456,7 +1456,7 @@ esac
 	os.Stdout = pw
 	defer func() { os.Stdout = origStdout }()
 
-	runErr := newApp().Run(ctx, []string{"horde", "list"})
+	runErr := newApp().Run(ctx, []string{"horde", "--provider", "docker", "list"})
 
 	pw.Close()
 	os.Stdout = origStdout
@@ -1532,7 +1532,7 @@ esac
 	os.Stdout = pw
 	defer func() { os.Stdout = origStdout }()
 
-	runErr := newApp().Run(ctx, []string{"horde", "list"})
+	runErr := newApp().Run(ctx, []string{"horde", "--provider", "docker", "list"})
 
 	pw.Close()
 	os.Stdout = origStdout
@@ -1598,7 +1598,7 @@ esac
 	os.Stdout = pw
 	defer func() { os.Stdout = origStdout }()
 
-	runErr := newApp().Run(ctx, []string{"horde", "list", "--all"})
+	runErr := newApp().Run(ctx, []string{"horde", "--provider", "docker", "list", "--all"})
 
 	pw.Close()
 	os.Stdout = origStdout
@@ -1669,7 +1669,7 @@ esac
 	os.Stderr = pwErr
 	defer func() { os.Stderr = origStderr }()
 
-	runErr := newApp().Run(ctx, []string{"horde", "list"})
+	runErr := newApp().Run(ctx, []string{"horde", "--provider", "docker", "list"})
 
 	pwOut.Close()
 	os.Stdout = origStdout
@@ -1727,7 +1727,7 @@ func TestList_TableFormat(t *testing.T) {
 	os.Stdout = pw
 	defer func() { os.Stdout = origStdout }()
 
-	runErr := newApp().Run(ctx, []string{"horde", "list", "--all"})
+	runErr := newApp().Run(ctx, []string{"horde", "--provider", "docker", "list", "--all"})
 
 	pw.Close()
 	os.Stdout = origStdout
@@ -1777,7 +1777,7 @@ func TestList_OtherRepoFiltered(t *testing.T) {
 	os.Stdout = pw
 	defer func() { os.Stdout = origStdout }()
 
-	runErr := newApp().Run(ctx, []string{"horde", "list"})
+	runErr := newApp().Run(ctx, []string{"horde", "--provider", "docker", "list"})
 
 	pw.Close()
 	os.Stdout = origStdout
@@ -1828,7 +1828,7 @@ func TestLogs_Success(t *testing.T) {
 	}
 	os.Stdout = pw
 	defer func() { os.Stdout = origStdout }()
-	runErr := newApp().Run(ctx, []string{"horde", "logs", runID})
+	runErr := newApp().Run(ctx, []string{"horde", "--provider", "docker", "logs", runID})
 	pw.Close()
 	os.Stdout = origStdout
 	out, _ := io.ReadAll(pr)
@@ -1877,7 +1877,7 @@ func TestLogs_Follow_Success(t *testing.T) {
 	}
 	os.Stdout = pw
 	defer func() { os.Stdout = origStdout }()
-	runErr := newApp().Run(ctx, []string{"horde", "logs", "--follow", runID})
+	runErr := newApp().Run(ctx, []string{"horde", "--provider", "docker", "logs", "--follow", runID})
 	pw.Close()
 	os.Stdout = origStdout
 	out, _ := io.ReadAll(pr)
@@ -1897,7 +1897,7 @@ func TestLogs_MissingRunID(t *testing.T) {
 	setupStatusEnv(t, "#!/bin/sh\n# no-op\n")
 	ctx := context.Background()
 
-	err := newApp().Run(ctx, []string{"horde", "logs"})
+	err := newApp().Run(ctx, []string{"horde", "--provider", "docker", "logs"})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -1919,7 +1919,7 @@ func TestLogs_RunNotFound(t *testing.T) {
 	}
 	st.Close()
 
-	err = newApp().Run(ctx, []string{"horde", "logs", "nonexistent"})
+	err = newApp().Run(ctx, []string{"horde", "--provider", "docker", "logs", "nonexistent"})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -1955,7 +1955,7 @@ func TestLogs_CompletedRun(t *testing.T) {
 			}
 			st.Close()
 
-			err = newApp().Run(ctx, []string{"horde", "logs", runID})
+			err = newApp().Run(ctx, []string{"horde", "--provider", "docker", "logs", runID})
 			if err == nil {
 				t.Fatal("expected error, got nil")
 			}
@@ -1994,7 +1994,7 @@ func TestLogs_PendingNoContainer(t *testing.T) {
 	}
 	st.Close()
 
-	err = newApp().Run(ctx, []string{"horde", "logs", runID})
+	err = newApp().Run(ctx, []string{"horde", "--provider", "docker", "logs", runID})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -2032,7 +2032,7 @@ func TestLogs_ContainerGone(t *testing.T) {
 	}
 	st.Close()
 
-	err = newApp().Run(ctx, []string{"horde", "logs", runID})
+	err = newApp().Run(ctx, []string{"horde", "--provider", "docker", "logs", runID})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -2047,7 +2047,7 @@ func TestKill_MissingRunID(t *testing.T) {
 	setupStatusEnv(t, "#!/bin/sh\n# no-op\n")
 	ctx := context.Background()
 
-	err := newApp().Run(ctx, []string{"horde", "kill"})
+	err := newApp().Run(ctx, []string{"horde", "--provider", "docker", "kill"})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -2066,7 +2066,7 @@ func TestKill_RunNotFound(t *testing.T) {
 	}
 	st.Close()
 
-	err = newApp().Run(ctx, []string{"horde", "kill", "nonexistent123"})
+	err = newApp().Run(ctx, []string{"horde", "--provider", "docker", "kill", "nonexistent123"})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -2101,7 +2101,7 @@ func TestKill_AlreadyCompleted(t *testing.T) {
 			}
 			st.Close()
 
-			err = newApp().Run(ctx, []string{"horde", "kill", runID})
+			err = newApp().Run(ctx, []string{"horde", "--provider", "docker", "kill", runID})
 			if err == nil {
 				t.Fatal("expected error, got nil")
 			}
@@ -2153,7 +2153,7 @@ esac
 	os.Stderr = stderrW
 	defer func() { os.Stderr = origStderr }()
 
-	runErr := newApp().Run(ctx, []string{"horde", "status", runID})
+	runErr := newApp().Run(ctx, []string{"horde", "--provider", "docker", "status", runID})
 
 	stderrW.Close()
 	os.Stderr = origStderr
@@ -2219,7 +2219,7 @@ esac
 	}
 	st.Close()
 
-	runErr := newApp().Run(ctx, []string{"horde", "status", runID})
+	runErr := newApp().Run(ctx, []string{"horde", "--provider", "docker", "status", runID})
 	if runErr != nil {
 		t.Fatalf("unexpected error: %v", runErr)
 	}
@@ -2285,7 +2285,7 @@ esac
 	}
 	st.Close()
 
-	runErr := newApp().Run(ctx, []string{"horde", "status", runID})
+	runErr := newApp().Run(ctx, []string{"horde", "--provider", "docker", "status", runID})
 	if runErr != nil {
 		t.Fatalf("unexpected error: %v", runErr)
 	}
@@ -2351,7 +2351,7 @@ esac
 	}
 	st.Close()
 
-	runErr := newApp().Run(ctx, []string{"horde", "status", runID})
+	runErr := newApp().Run(ctx, []string{"horde", "--provider", "docker", "status", runID})
 	if runErr != nil {
 		t.Fatalf("unexpected error: %v", runErr)
 	}
@@ -2416,7 +2416,7 @@ esac
 	pr, pw, _ := os.Pipe()
 	os.Stdout = pw
 	defer func() { os.Stdout = origStdout }()
-	runErr := newApp().Run(ctx, []string{"horde", "kill", runID})
+	runErr := newApp().Run(ctx, []string{"horde", "--provider", "docker", "kill", runID})
 	pw.Close()
 	os.Stdout = origStdout
 	out, _ := io.ReadAll(pr)
@@ -2480,7 +2480,7 @@ func TestKill_PendingRun(t *testing.T) {
 	pr, pw, _ := os.Pipe()
 	os.Stdout = pw
 	defer func() { os.Stdout = origStdout }()
-	runErr := newApp().Run(ctx, []string{"horde", "kill", runID})
+	runErr := newApp().Run(ctx, []string{"horde", "--provider", "docker", "kill", runID})
 	pw.Close()
 	os.Stdout = origStdout
 	out, _ := io.ReadAll(pr)
@@ -2551,7 +2551,7 @@ esac
 	pr, pw, _ := os.Pipe()
 	os.Stdout = pw
 	defer func() { os.Stdout = origStdout }()
-	runErr := newApp().Run(ctx, []string{"horde", "kill", runID})
+	runErr := newApp().Run(ctx, []string{"horde", "--provider", "docker", "kill", runID})
 	pw.Close()
 	os.Stdout = origStdout
 	out, _ := io.ReadAll(pr)
@@ -2628,7 +2628,7 @@ esac
 	pr, pw, _ := os.Pipe()
 	os.Stdout = pw
 	defer func() { os.Stdout = origStdout }()
-	runErr := newApp().Run(ctx, []string{"horde", "kill", runID})
+	runErr := newApp().Run(ctx, []string{"horde", "--provider", "docker", "kill", runID})
 	pw.Close()
 	os.Stdout = origStdout
 	out, _ := io.ReadAll(pr)
@@ -2668,7 +2668,7 @@ esac
 func TestResults_MissingRunID(t *testing.T) {
 	setupStatusEnv(t, "#!/bin/sh\n# no-op\n")
 	ctx := context.Background()
-	err := newApp().Run(ctx, []string{"horde", "results"})
+	err := newApp().Run(ctx, []string{"horde", "--provider", "docker", "results"})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -2688,7 +2688,7 @@ func TestResults_RunNotFound(t *testing.T) {
 		t.Fatalf("opening store: %v", err)
 	}
 	st.Close()
-	err = newApp().Run(ctx, []string{"horde", "results", "nonexistent"})
+	err = newApp().Run(ctx, []string{"horde", "--provider", "docker", "results", "nonexistent"})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -2720,7 +2720,7 @@ func TestResults_StillRunning(t *testing.T) {
 	pr, pw, _ := os.Pipe()
 	os.Stdout = pw
 	defer func() { os.Stdout = origStdout }()
-	runErr := newApp().Run(ctx, []string{"horde", "results", runID})
+	runErr := newApp().Run(ctx, []string{"horde", "--provider", "docker", "results", runID})
 	pw.Close()
 	os.Stdout = origStdout
 	out, _ := io.ReadAll(pr)
@@ -2766,7 +2766,7 @@ func TestResults_CompletedWithResults(t *testing.T) {
 	pr, pw, _ := os.Pipe()
 	os.Stdout = pw
 	defer func() { os.Stdout = origStdout }()
-	runErr := newApp().Run(ctx, []string{"horde", "results", runID})
+	runErr := newApp().Run(ctx, []string{"horde", "--provider", "docker", "results", runID})
 	pw.Close()
 	os.Stdout = origStdout
 	out, _ := io.ReadAll(pr)
@@ -2811,7 +2811,7 @@ func TestResults_CompletedNoCost(t *testing.T) {
 	pr, pw, _ := os.Pipe()
 	os.Stdout = pw
 	defer func() { os.Stdout = origStdout }()
-	runErr := newApp().Run(ctx, []string{"horde", "results", runID})
+	runErr := newApp().Run(ctx, []string{"horde", "--provider", "docker", "results", runID})
 	pw.Close()
 	os.Stdout = origStdout
 	out, _ := io.ReadAll(pr)
@@ -2859,7 +2859,7 @@ func TestResults_CompletedWithWorkflow(t *testing.T) {
 	pr, pw, _ := os.Pipe()
 	os.Stdout = pw
 	defer func() { os.Stdout = origStdout }()
-	runErr := newApp().Run(ctx, []string{"horde", "results", runID})
+	runErr := newApp().Run(ctx, []string{"horde", "--provider", "docker", "results", runID})
 	pw.Close()
 	os.Stdout = origStdout
 	out, _ := io.ReadAll(pr)
@@ -2902,7 +2902,7 @@ func TestResults_MissingRunResult(t *testing.T) {
 	pr, pw, _ := os.Pipe()
 	os.Stdout = pw
 	defer func() { os.Stdout = origStdout }()
-	runErr := newApp().Run(ctx, []string{"horde", "results", runID})
+	runErr := newApp().Run(ctx, []string{"horde", "--provider", "docker", "results", runID})
 	pw.Close()
 	os.Stdout = origStdout
 	out, _ := io.ReadAll(pr)
@@ -2940,7 +2940,7 @@ func TestResults_LazyCompletion(t *testing.T) {
 	pr, pw, _ := os.Pipe()
 	os.Stdout = pw
 	defer func() { os.Stdout = origStdout }()
-	runErr := newApp().Run(ctx, []string{"horde", "results", runID})
+	runErr := newApp().Run(ctx, []string{"horde", "--provider", "docker", "results", runID})
 	pw.Close()
 	os.Stdout = origStdout
 	out, _ := io.ReadAll(pr)

--- a/cmd/horde/main_test.go
+++ b/cmd/horde/main_test.go
@@ -3014,3 +3014,101 @@ func TestResolveLaunchedBy_UnsupportedProvider(t *testing.T) {
 		t.Errorf("error = %q, want it to contain %q", err.Error(), "unsupported provider")
 	}
 }
+
+func TestOpenStore_Docker(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	st, cleanup, err := openStore("docker")
+	if err != nil {
+		t.Fatalf("openStore(docker) error: %v", err)
+	}
+	defer cleanup()
+
+	ctx := context.Background()
+	run := &store.Run{
+		ID:        "testrun123ab",
+		Repo:      "github.com/test/repo.git",
+		Ticket:    "TEST-1",
+		Provider:  "docker",
+		Status:    store.StatusPending,
+		StartedAt: time.Now(),
+		TimeoutAt: time.Now().Add(time.Hour),
+	}
+	if err := st.CreateRun(ctx, run); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	got, err := st.GetRun(ctx, "testrun123ab")
+	if err != nil {
+		t.Fatalf("GetRun: %v", err)
+	}
+	if got.Ticket != "TEST-1" {
+		t.Errorf("Ticket = %q, want %q", got.Ticket, "TEST-1")
+	}
+}
+
+func TestOpenStore_Docker_Cleanup(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	st, cleanup, err := openStore("docker")
+	if err != nil {
+		t.Fatalf("openStore(docker) error: %v", err)
+	}
+
+	cleanup() // Close the store
+
+	ctx := context.Background()
+	_, err = st.GetRun(ctx, "nonexistent")
+	if err == nil {
+		t.Fatal("expected error after cleanup, got nil")
+	}
+}
+
+func TestOpenStore_Unsupported(t *testing.T) {
+	t.Parallel()
+	_, _, err := openStore("gcp")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "unsupported provider") {
+		t.Errorf("error %q does not contain expected message", err.Error())
+	}
+}
+
+func TestProvider_AWSECS_SSMError(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+	t.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+
+	_ = setupLaunchEnv(t)
+	ctx := context.Background()
+
+	err := newApp().Run(ctx, []string{"horde", "--provider", "aws-ecs", "launch", "TICKET-1"})
+	if err == nil {
+		t.Fatal("expected error for aws-ecs provider, got nil")
+	}
+	// Before hook (in this bead) catches "aws-ecs" first; after d69.4.2 the factory fires.
+	// Either way, the error must mention "aws-ecs".
+	if !strings.Contains(err.Error(), "aws-ecs") {
+		t.Errorf("error %q does not mention aws-ecs", err.Error())
+	}
+}
+
+func TestProvider_AutoDetect_Error(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+	t.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+
+	_ = setupLaunchEnv(t)
+	ctx := context.Background()
+
+	// With --provider defaulting to "docker" and the Before hook in place,
+	// this may succeed. After d69.4.2 removes the Before hook and changes
+	// the default to "", it will fail with the auto-detect error.
+	err := newApp().Run(ctx, []string{"horde", "launch", "TICKET-1"})
+	if err != nil && !strings.Contains(err.Error(), "auto-detecting") &&
+		!strings.Contains(err.Error(), "--provider docker") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,10 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.68.4
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.10
+	github.com/aws/smithy-go v1.24.2
 	github.com/mattn/go-sqlite3 v1.14.42
 	github.com/urfave/cli/v3 v3.8.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -31,6 +33,4 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 // indirect
-	github.com/aws/smithy-go v1.24.2 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,7 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/urfave/cli/v3 v3.8.0 h1:XqKPrm0q4P0q5JpoclYoCAv0/MIvH/jZ2umzuf8pNTI=
 github.com/urfave/cli/v3 v3.8.0/go.mod h1:ysVLtOEmg2tOy6PknnYVhDoouyC/6N42TMeoMzskhso=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/config/ssm.go
+++ b/internal/config/ssm.go
@@ -3,10 +3,13 @@ package config
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	smithy "github.com/aws/smithy-go"
 )
 
 const DefaultSSMPath = "/horde/config"
@@ -51,6 +54,36 @@ func (e *ParseError) Error() string {
 }
 
 func (e *ParseError) Unwrap() error { return e.Err }
+
+// LoadFromSSM reads the horde configuration from an SSM parameter at the given path.
+// It returns typed errors: *NotFoundError, *AccessDeniedError, or *ParseError.
+func LoadFromSSM(ctx context.Context, client SSMClient, path string) (*HordeConfig, error) {
+	out, err := client.GetParameter(ctx, &ssm.GetParameterInput{
+		Name: &path,
+	})
+	if err != nil {
+		var notFound *ssmtypes.ParameterNotFound
+		if errors.As(err, &notFound) {
+			return nil, &NotFoundError{Path: path, Err: err}
+		}
+		var apiErr smithy.APIError
+		if errors.As(err, &apiErr) && apiErr.ErrorCode() == "AccessDeniedException" {
+			return nil, &AccessDeniedError{Path: path, Err: err}
+		}
+		return nil, fmt.Errorf("reading ssm parameter %q: %w", path, err)
+	}
+	if out.Parameter == nil || out.Parameter.Value == nil {
+		return nil, &ParseError{
+			Path: path,
+			Err:  fmt.Errorf("parameter value is nil"),
+		}
+	}
+	cfg, err := ParseHordeConfig([]byte(*out.Parameter.Value))
+	if err != nil {
+		return nil, &ParseError{Path: path, Err: err}
+	}
+	return cfg, nil
+}
 
 // HordeConfig holds ECS infrastructure configuration discovered from SSM.
 // JSON tags match the parameter written by the CDK construct at /horde/config.

--- a/internal/config/ssm.go
+++ b/internal/config/ssm.go
@@ -1,10 +1,56 @@
 package config
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
 )
+
+const DefaultSSMPath = "/horde/config"
+
+// SSMClient is the subset of the SSM API used by LoadFromSSM.
+type SSMClient interface {
+	GetParameter(ctx context.Context, params *ssm.GetParameterInput, optFns ...func(*ssm.Options)) (*ssm.GetParameterOutput, error)
+}
+
+// NotFoundError is returned when the SSM parameter does not exist.
+type NotFoundError struct {
+	Path string
+	Err  error
+}
+
+func (e *NotFoundError) Error() string {
+	return fmt.Sprintf("ssm parameter %q not found: %v", e.Path, e.Err)
+}
+
+func (e *NotFoundError) Unwrap() error { return e.Err }
+
+// AccessDeniedError is returned when the caller lacks permission to read the SSM parameter.
+type AccessDeniedError struct {
+	Path string
+	Err  error
+}
+
+func (e *AccessDeniedError) Error() string {
+	return fmt.Sprintf("access denied reading ssm parameter %q: %v", e.Path, e.Err)
+}
+
+func (e *AccessDeniedError) Unwrap() error { return e.Err }
+
+// ParseError is returned when the SSM parameter value cannot be parsed or validated.
+type ParseError struct {
+	Path string
+	Err  error
+}
+
+func (e *ParseError) Error() string {
+	return fmt.Sprintf("parsing ssm parameter %q: %v", e.Path, e.Err)
+}
+
+func (e *ParseError) Unwrap() error { return e.Err }
 
 // HordeConfig holds ECS infrastructure configuration discovered from SSM.
 // JSON tags match the parameter written by the CDK construct at /horde/config.

--- a/internal/config/ssm.go
+++ b/internal/config/ssm.go
@@ -87,6 +87,9 @@ func LoadFromSSM(ctx context.Context, client SSMClient, path string) (*HordeConf
 
 // Diagnostic maps a typed SSM error to a user-friendly, actionable message.
 func Diagnostic(err error) string {
+	if err == nil {
+		return ""
+	}
 	var nf *NotFoundError
 	if errors.As(err, &nf) {
 		return fmt.Sprintf("ssm parameter %q not found\n\nhint: deploy the @horde/cdk construct to create the SSM parameter.\nSee: https://github.com/jorge-barreto/horde/tree/main/cdk", nf.Path)

--- a/internal/config/ssm.go
+++ b/internal/config/ssm.go
@@ -1,0 +1,69 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// HordeConfig holds ECS infrastructure configuration discovered from SSM.
+// JSON tags match the parameter written by the CDK construct at /horde/config.
+type HordeConfig struct {
+	ClusterARN            string   `json:"cluster_arn"`
+	TaskDefinitionARN     string   `json:"task_definition_arn"`
+	Subnets               []string `json:"subnets"`
+	SecurityGroup         string   `json:"security_group"`
+	LogGroup              string   `json:"log_group"`
+	ArtifactsBucket       string   `json:"artifacts_bucket"`
+	RunsTable             string   `json:"runs_table"`
+	MaxConcurrent         int      `json:"max_concurrent"`
+	DefaultTimeoutMinutes int      `json:"default_timeout_minutes"`
+}
+
+// Validate checks that all required fields are present and valid.
+func (c *HordeConfig) Validate() error {
+	var missing []string
+	if c.ClusterARN == "" {
+		missing = append(missing, "cluster_arn")
+	}
+	if c.TaskDefinitionARN == "" {
+		missing = append(missing, "task_definition_arn")
+	}
+	if len(c.Subnets) == 0 {
+		missing = append(missing, "subnets")
+	}
+	if c.SecurityGroup == "" {
+		missing = append(missing, "security_group")
+	}
+	if c.LogGroup == "" {
+		missing = append(missing, "log_group")
+	}
+	if c.ArtifactsBucket == "" {
+		missing = append(missing, "artifacts_bucket")
+	}
+	if c.RunsTable == "" {
+		missing = append(missing, "runs_table")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("validating horde config: missing required fields: %s", strings.Join(missing, ", "))
+	}
+	if c.MaxConcurrent < 1 {
+		return fmt.Errorf("validating horde config: max_concurrent must be at least 1, got %d", c.MaxConcurrent)
+	}
+	if c.DefaultTimeoutMinutes < 1 {
+		return fmt.Errorf("validating horde config: default_timeout_minutes must be at least 1, got %d", c.DefaultTimeoutMinutes)
+	}
+	return nil
+}
+
+// ParseHordeConfig unmarshals JSON data into a HordeConfig and validates all fields.
+func ParseHordeConfig(data []byte) (*HordeConfig, error) {
+	var cfg HordeConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing horde config: %w", err)
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}

--- a/internal/config/ssm.go
+++ b/internal/config/ssm.go
@@ -85,6 +85,23 @@ func LoadFromSSM(ctx context.Context, client SSMClient, path string) (*HordeConf
 	return cfg, nil
 }
 
+// Diagnostic maps a typed SSM error to a user-friendly, actionable message.
+func Diagnostic(err error) string {
+	var nf *NotFoundError
+	if errors.As(err, &nf) {
+		return fmt.Sprintf("ssm parameter %q not found\n\nhint: deploy the @horde/cdk construct to create the SSM parameter.\nSee: https://github.com/jorge-barreto/horde/tree/main/cdk", nf.Path)
+	}
+	var ad *AccessDeniedError
+	if errors.As(err, &ad) {
+		return fmt.Sprintf("access denied reading ssm parameter %q\n\nhint: attach the horde CLI user managed policy to your IAM role or user.\nThe policy ARN is an output of the @horde/cdk construct.", ad.Path)
+	}
+	var pe *ParseError
+	if errors.As(err, &pe) {
+		return fmt.Sprintf("parsing ssm parameter %q: %v\n\nhint: the SSM parameter is malformed. Re-deploy the @horde/cdk construct to regenerate it.", pe.Path, pe.Err)
+	}
+	return err.Error()
+}
+
 // HordeConfig holds ECS infrastructure configuration discovered from SSM.
 // JSON tags match the parameter written by the CDK construct at /horde/config.
 type HordeConfig struct {

--- a/internal/config/ssm_test.go
+++ b/internal/config/ssm_test.go
@@ -423,6 +423,21 @@ func TestDiagnostic(t *testing.T) {
 			want:   []string{"connection refused"},
 			noWant: []string{"hint:"},
 		},
+		{
+			name: "wrapped not found",
+			err:  fmt.Errorf("wrapped: %w", &NotFoundError{Path: "/horde/config", Err: fmt.Errorf("underlying")}),
+			want: []string{"/horde/config", "deploy the @horde/cdk construct"},
+		},
+		{
+			name: "wrapped access denied",
+			err:  fmt.Errorf("wrapped: %w", &AccessDeniedError{Path: "/horde/config", Err: fmt.Errorf("underlying")}),
+			want: []string{"/horde/config", "attach the horde CLI user managed policy", "@horde/cdk construct"},
+		},
+		{
+			name: "wrapped parse error",
+			err:  fmt.Errorf("wrapped: %w", &ParseError{Path: "/horde/config", Err: fmt.Errorf("invalid json")}),
+			want: []string{"/horde/config", "malformed", "Re-deploy", "invalid json"},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -440,6 +455,13 @@ func TestDiagnostic(t *testing.T) {
 			}
 		})
 	}
+	t.Run("nil error", func(t *testing.T) {
+		t.Parallel()
+		got := Diagnostic(nil)
+		if got != "" {
+			t.Errorf("Diagnostic(nil) = %q, want empty string", got)
+		}
+	})
 }
 
 func TestHordeConfig_Validate_AllFieldsPresent(t *testing.T) {

--- a/internal/config/ssm_test.go
+++ b/internal/config/ssm_test.go
@@ -1,9 +1,16 @@
 package config
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	smithy "github.com/aws/smithy-go"
 )
 
 func validHordeFields() map[string]interface{} {
@@ -27,6 +34,165 @@ func marshalFields(t *testing.T, fields map[string]interface{}) []byte {
 		t.Fatalf("marshaling fields: %v", err)
 	}
 	return data
+}
+
+type fakeSSMClient struct {
+	output *ssm.GetParameterOutput
+	err    error
+}
+
+func (f *fakeSSMClient) GetParameter(_ context.Context, _ *ssm.GetParameterInput, _ ...func(*ssm.Options)) (*ssm.GetParameterOutput, error) {
+	return f.output, f.err
+}
+
+func TestLoadFromSSM_Success(t *testing.T) {
+	t.Parallel()
+	fields := validHordeFields()
+	data := marshalFields(t, fields)
+	val := string(data)
+	client := &fakeSSMClient{
+		output: &ssm.GetParameterOutput{
+			Parameter: &ssmtypes.Parameter{Value: aws.String(val)},
+		},
+	}
+	cfg, err := LoadFromSSM(context.Background(), client, "/horde/config")
+	if err != nil {
+		t.Fatalf("LoadFromSSM() unexpected error: %v", err)
+	}
+	if cfg.ClusterARN != "arn:aws:ecs:us-east-1:123456789012:cluster/horde" {
+		t.Errorf("ClusterARN = %q, want %q", cfg.ClusterARN, "arn:aws:ecs:us-east-1:123456789012:cluster/horde")
+	}
+	if cfg.MaxConcurrent != 5 {
+		t.Errorf("MaxConcurrent = %d, want 5", cfg.MaxConcurrent)
+	}
+}
+
+func TestLoadFromSSM_NotFound(t *testing.T) {
+	t.Parallel()
+	client := &fakeSSMClient{
+		err: &ssmtypes.ParameterNotFound{Message: aws.String("not found")},
+	}
+	_, err := LoadFromSSM(context.Background(), client, "/horde/config")
+	if err == nil {
+		t.Fatal("LoadFromSSM() expected error, got nil")
+	}
+	var target *NotFoundError
+	if !errors.As(err, &target) {
+		t.Errorf("expected *NotFoundError, got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), "/horde/config") {
+		t.Errorf("error = %q, want it to contain path", err.Error())
+	}
+}
+
+func TestLoadFromSSM_AccessDenied(t *testing.T) {
+	t.Parallel()
+	client := &fakeSSMClient{
+		err: &smithy.GenericAPIError{Code: "AccessDeniedException", Message: "User is not authorized"},
+	}
+	_, err := LoadFromSSM(context.Background(), client, "/horde/config")
+	if err == nil {
+		t.Fatal("LoadFromSSM() expected error, got nil")
+	}
+	var target *AccessDeniedError
+	if !errors.As(err, &target) {
+		t.Errorf("expected *AccessDeniedError, got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), "access denied") {
+		t.Errorf("error = %q, want it to contain %q", err.Error(), "access denied")
+	}
+}
+
+func TestLoadFromSSM_ParseError_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	client := &fakeSSMClient{
+		output: &ssm.GetParameterOutput{
+			Parameter: &ssmtypes.Parameter{Value: aws.String("{not json}")},
+		},
+	}
+	_, err := LoadFromSSM(context.Background(), client, "/horde/config")
+	if err == nil {
+		t.Fatal("LoadFromSSM() expected error, got nil")
+	}
+	var target *ParseError
+	if !errors.As(err, &target) {
+		t.Errorf("expected *ParseError, got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), "/horde/config") {
+		t.Errorf("error = %q, want it to contain path", err.Error())
+	}
+}
+
+func TestLoadFromSSM_ParseError_ValidationFailure(t *testing.T) {
+	t.Parallel()
+	fields := validHordeFields()
+	fields["max_concurrent"] = 0
+	data := marshalFields(t, fields)
+	client := &fakeSSMClient{
+		output: &ssm.GetParameterOutput{
+			Parameter: &ssmtypes.Parameter{Value: aws.String(string(data))},
+		},
+	}
+	_, err := LoadFromSSM(context.Background(), client, "/horde/config")
+	if err == nil {
+		t.Fatal("LoadFromSSM() expected error, got nil")
+	}
+	var target *ParseError
+	if !errors.As(err, &target) {
+		t.Errorf("expected *ParseError, got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), "max_concurrent must be at least 1") {
+		t.Errorf("error = %q, want it to contain %q", err.Error(), "max_concurrent must be at least 1")
+	}
+}
+
+func TestLoadFromSSM_NilValue(t *testing.T) {
+	t.Parallel()
+	client := &fakeSSMClient{
+		output: &ssm.GetParameterOutput{
+			Parameter: &ssmtypes.Parameter{},
+		},
+	}
+	_, err := LoadFromSSM(context.Background(), client, "/horde/config")
+	if err == nil {
+		t.Fatal("LoadFromSSM() expected error, got nil")
+	}
+	var target *ParseError
+	if !errors.As(err, &target) {
+		t.Errorf("expected *ParseError, got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), "nil") {
+		t.Errorf("error = %q, want it to contain %q", err.Error(), "nil")
+	}
+}
+
+func TestLoadFromSSM_UnclassifiedError(t *testing.T) {
+	t.Parallel()
+	client := &fakeSSMClient{
+		err: errors.New("connection refused"),
+	}
+	_, err := LoadFromSSM(context.Background(), client, "/horde/config")
+	if err == nil {
+		t.Fatal("LoadFromSSM() expected error, got nil")
+	}
+	var nf *NotFoundError
+	if errors.As(err, &nf) {
+		t.Errorf("unexpected *NotFoundError")
+	}
+	var ad *AccessDeniedError
+	if errors.As(err, &ad) {
+		t.Errorf("unexpected *AccessDeniedError")
+	}
+	var pe *ParseError
+	if errors.As(err, &pe) {
+		t.Errorf("unexpected *ParseError")
+	}
+	if !strings.Contains(err.Error(), "reading ssm parameter") {
+		t.Errorf("error = %q, want it to contain %q", err.Error(), "reading ssm parameter")
+	}
+	if !strings.Contains(err.Error(), "/horde/config") {
+		t.Errorf("error = %q, want it to contain path", err.Error())
+	}
 }
 
 func TestParseHordeConfig_Valid(t *testing.T) {

--- a/internal/config/ssm_test.go
+++ b/internal/config/ssm_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -390,6 +391,54 @@ func TestParseHordeConfig_ExtraFieldsIgnored(t *testing.T) {
 	_, err := ParseHordeConfig(marshalFields(t, fields))
 	if err != nil {
 		t.Fatalf("ParseHordeConfig() with extra field error: %v", err)
+	}
+}
+
+func TestDiagnostic(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		err    error
+		want   []string
+		noWant []string
+	}{
+		{
+			name: "not found",
+			err:  &NotFoundError{Path: "/horde/config", Err: fmt.Errorf("underlying")},
+			want: []string{"/horde/config", "deploy the @horde/cdk construct"},
+		},
+		{
+			name: "access denied",
+			err:  &AccessDeniedError{Path: "/horde/config", Err: fmt.Errorf("underlying")},
+			want: []string{"/horde/config", "attach the horde CLI user managed policy", "@horde/cdk construct"},
+		},
+		{
+			name: "parse error",
+			err:  &ParseError{Path: "/horde/config", Err: fmt.Errorf("invalid json")},
+			want: []string{"/horde/config", "malformed", "Re-deploy", "invalid json"},
+		},
+		{
+			name:   "unrecognized error",
+			err:    fmt.Errorf("connection refused"),
+			want:   []string{"connection refused"},
+			noWant: []string{"hint:"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := Diagnostic(tc.err)
+			for _, w := range tc.want {
+				if !strings.Contains(got, w) {
+					t.Errorf("Diagnostic() = %q, want it to contain %q", got, w)
+				}
+			}
+			for _, nw := range tc.noWant {
+				if strings.Contains(got, nw) {
+					t.Errorf("Diagnostic() = %q, should not contain %q", got, nw)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/config/ssm_test.go
+++ b/internal/config/ssm_test.go
@@ -1,0 +1,246 @@
+package config
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func validHordeFields() map[string]interface{} {
+	return map[string]interface{}{
+		"cluster_arn":             "arn:aws:ecs:us-east-1:123456789012:cluster/horde",
+		"task_definition_arn":     "arn:aws:ecs:us-east-1:123456789012:task-definition/horde-worker:1",
+		"subnets":                 []string{"subnet-abc", "subnet-def"},
+		"security_group":          "sg-123",
+		"log_group":               "/ecs/horde-worker",
+		"artifacts_bucket":        "my-horde-artifacts",
+		"runs_table":              "horde-runs",
+		"max_concurrent":          5,
+		"default_timeout_minutes": 60,
+	}
+}
+
+func marshalFields(t *testing.T, fields map[string]interface{}) []byte {
+	t.Helper()
+	data, err := json.Marshal(fields)
+	if err != nil {
+		t.Fatalf("marshaling fields: %v", err)
+	}
+	return data
+}
+
+func TestParseHordeConfig_Valid(t *testing.T) {
+	t.Parallel()
+	cfg, err := ParseHordeConfig(marshalFields(t, validHordeFields()))
+	if err != nil {
+		t.Fatalf("ParseHordeConfig() error: %v", err)
+	}
+	if cfg.ClusterARN != "arn:aws:ecs:us-east-1:123456789012:cluster/horde" {
+		t.Errorf("ClusterARN = %q, want %q", cfg.ClusterARN, "arn:aws:ecs:us-east-1:123456789012:cluster/horde")
+	}
+	if cfg.TaskDefinitionARN != "arn:aws:ecs:us-east-1:123456789012:task-definition/horde-worker:1" {
+		t.Errorf("TaskDefinitionARN = %q, want %q", cfg.TaskDefinitionARN, "arn:aws:ecs:us-east-1:123456789012:task-definition/horde-worker:1")
+	}
+	if len(cfg.Subnets) != 2 {
+		t.Fatalf("Subnets length = %d, want 2", len(cfg.Subnets))
+	}
+	if cfg.Subnets[0] != "subnet-abc" {
+		t.Errorf("Subnets[0] = %q, want %q", cfg.Subnets[0], "subnet-abc")
+	}
+	if cfg.Subnets[1] != "subnet-def" {
+		t.Errorf("Subnets[1] = %q, want %q", cfg.Subnets[1], "subnet-def")
+	}
+	if cfg.SecurityGroup != "sg-123" {
+		t.Errorf("SecurityGroup = %q, want %q", cfg.SecurityGroup, "sg-123")
+	}
+	if cfg.LogGroup != "/ecs/horde-worker" {
+		t.Errorf("LogGroup = %q, want %q", cfg.LogGroup, "/ecs/horde-worker")
+	}
+	if cfg.ArtifactsBucket != "my-horde-artifacts" {
+		t.Errorf("ArtifactsBucket = %q, want %q", cfg.ArtifactsBucket, "my-horde-artifacts")
+	}
+	if cfg.RunsTable != "horde-runs" {
+		t.Errorf("RunsTable = %q, want %q", cfg.RunsTable, "horde-runs")
+	}
+	if cfg.MaxConcurrent != 5 {
+		t.Errorf("MaxConcurrent = %d, want 5", cfg.MaxConcurrent)
+	}
+	if cfg.DefaultTimeoutMinutes != 60 {
+		t.Errorf("DefaultTimeoutMinutes = %d, want 60", cfg.DefaultTimeoutMinutes)
+	}
+}
+
+func TestParseHordeConfig_JSONRoundTrip(t *testing.T) {
+	t.Parallel()
+	cfg := HordeConfig{
+		ClusterARN:            "arn:aws:ecs:us-east-1:123:cluster/horde",
+		TaskDefinitionARN:     "arn:aws:ecs:us-east-1:123:task-definition/horde-worker:1",
+		Subnets:               []string{"subnet-abc", "subnet-def"},
+		SecurityGroup:         "sg-123",
+		LogGroup:              "/ecs/horde-worker",
+		ArtifactsBucket:       "my-horde-artifacts",
+		RunsTable:             "horde-runs",
+		MaxConcurrent:         5,
+		DefaultTimeoutMinutes: 60,
+	}
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("json.Marshal() error: %v", err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("json.Unmarshal() error: %v", err)
+	}
+	wantKeys := []string{
+		"cluster_arn", "task_definition_arn", "subnets", "security_group",
+		"log_group", "artifacts_bucket", "runs_table", "max_concurrent",
+		"default_timeout_minutes",
+	}
+	for _, key := range wantKeys {
+		if _, ok := m[key]; !ok {
+			t.Errorf("JSON output missing key %q", key)
+		}
+	}
+}
+
+func TestParseHordeConfig_MissingFields(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		mutate  func(map[string]interface{})
+		wantErr []string
+	}{
+		{
+			name:    "missing cluster_arn",
+			mutate:  func(m map[string]interface{}) { delete(m, "cluster_arn") },
+			wantErr: []string{"missing required fields: cluster_arn"},
+		},
+		{
+			name:    "missing task_definition_arn",
+			mutate:  func(m map[string]interface{}) { delete(m, "task_definition_arn") },
+			wantErr: []string{"missing required fields: task_definition_arn"},
+		},
+		{
+			name:    "missing subnets",
+			mutate:  func(m map[string]interface{}) { delete(m, "subnets") },
+			wantErr: []string{"missing required fields: subnets"},
+		},
+		{
+			name:    "empty subnets",
+			mutate:  func(m map[string]interface{}) { m["subnets"] = []string{} },
+			wantErr: []string{"missing required fields: subnets"},
+		},
+		{
+			name:    "missing security_group",
+			mutate:  func(m map[string]interface{}) { delete(m, "security_group") },
+			wantErr: []string{"missing required fields: security_group"},
+		},
+		{
+			name:    "missing log_group",
+			mutate:  func(m map[string]interface{}) { delete(m, "log_group") },
+			wantErr: []string{"missing required fields: log_group"},
+		},
+		{
+			name:    "missing artifacts_bucket",
+			mutate:  func(m map[string]interface{}) { delete(m, "artifacts_bucket") },
+			wantErr: []string{"missing required fields: artifacts_bucket"},
+		},
+		{
+			name:    "missing runs_table",
+			mutate:  func(m map[string]interface{}) { delete(m, "runs_table") },
+			wantErr: []string{"missing required fields: runs_table"},
+		},
+		{
+			name: "multiple missing",
+			mutate: func(m map[string]interface{}) {
+				delete(m, "cluster_arn")
+				delete(m, "log_group")
+			},
+			wantErr: []string{"cluster_arn", "log_group"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fields := validHordeFields()
+			tc.mutate(fields)
+			_, err := ParseHordeConfig(marshalFields(t, fields))
+			if err == nil {
+				t.Fatalf("ParseHordeConfig() expected error, got nil")
+			}
+			for _, want := range tc.wantErr {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error = %q, want it to contain %q", err.Error(), want)
+				}
+			}
+		})
+	}
+}
+
+func TestParseHordeConfig_InvalidInts(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		field   string
+		value   int
+		wantErr string
+	}{
+		{"max_concurrent zero", "max_concurrent", 0, "max_concurrent must be at least 1"},
+		{"max_concurrent negative", "max_concurrent", -1, "max_concurrent must be at least 1"},
+		{"default_timeout_minutes zero", "default_timeout_minutes", 0, "default_timeout_minutes must be at least 1"},
+		{"default_timeout_minutes negative", "default_timeout_minutes", -5, "default_timeout_minutes must be at least 1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fields := validHordeFields()
+			fields[tc.field] = tc.value
+			_, err := ParseHordeConfig(marshalFields(t, fields))
+			if err == nil {
+				t.Fatalf("ParseHordeConfig() expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error = %q, want it to contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseHordeConfig_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	_, err := ParseHordeConfig([]byte("{not json"))
+	if err == nil {
+		t.Fatal("ParseHordeConfig() expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "parsing horde config") {
+		t.Errorf("error = %q, want it to contain %q", err.Error(), "parsing horde config")
+	}
+}
+
+func TestParseHordeConfig_ExtraFieldsIgnored(t *testing.T) {
+	t.Parallel()
+	fields := validHordeFields()
+	fields["new_future_field"] = "value"
+	_, err := ParseHordeConfig(marshalFields(t, fields))
+	if err != nil {
+		t.Fatalf("ParseHordeConfig() with extra field error: %v", err)
+	}
+}
+
+func TestHordeConfig_Validate_AllFieldsPresent(t *testing.T) {
+	t.Parallel()
+	cfg := HordeConfig{
+		ClusterARN:            "arn:aws:ecs:us-east-1:123:cluster/horde",
+		TaskDefinitionARN:     "arn:aws:ecs:us-east-1:123:task-definition/horde-worker:1",
+		Subnets:               []string{"subnet-abc"},
+		SecurityGroup:         "sg-123",
+		LogGroup:              "/ecs/horde-worker",
+		ArtifactsBucket:       "my-bucket",
+		RunsTable:             "horde-runs",
+		MaxConcurrent:         1,
+		DefaultTimeoutMinutes: 1,
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() unexpected error: %v", err)
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -17,13 +17,13 @@ type Provider interface {
 
 // LaunchOpts contains parameters for launching a worker instance.
 type LaunchOpts struct {
-	Repo       string
-	Ticket     string
-	Branch     string
-	Workflow   string
-	RunID      string
-	EnvFile    string   // path to .env file (docker provider)
-	Mounts []string // volume mounts in docker format (host:container)
+	Repo     string
+	Ticket   string
+	Branch   string
+	Workflow string
+	RunID    string
+	EnvFile  string   // path to .env file (docker provider)
+	Mounts   []string // volume mounts in docker format (host:container)
 }
 
 // LaunchResult contains the outcome of a successful launch.


### PR DESCRIPTION
## Summary

Automated implementation for `horde-d69`.

## Commits

```
a7bf160 horde-d69.5.1: Extract factory.go and wire main.go delegation
bd50b0c horde-d69.4.2: Wire factory into all 9 commands; update flag, hook, tests, README
50c269e horde-d69.4.1: Add initProviderAndStore and openStore factory helpers
1414213 horde-d69.3.2: fix nil panic in Diagnostic and add wrapped-error test coverage
e60935f horde-d69.3.1: add Diagnostic function for SSM error messages
0e0d8d2 horde-d69.2.2: implement LoadFromSSM with error classification and tests
623741a horde-d69.2.1: add SSMClient interface and typed error types
5ec6496 horde-d69.1.1: define HordeConfig struct and ParseHordeConfig with tests
```
