### PR TITLE
Map ECS transitional states to pending/stopping in Status()

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -465,7 +465,7 @@ The format is chosen to be:
 ### v0.2 — Baseline
 
 - **Scoped IAM for tasks**: Task role can only write to the artifacts S3 bucket and read specific secrets. No EC2, no other AWS services.
-- **Scoped IAM for CLI users**: The CDK construct outputs a managed policy ARN. Developers need: `ecs:RunTask`, `ecs:DescribeTasks`, `ecs:StopTask`, `ecs:TagResource` on the cluster; `ssm:GetParameter` on `/horde/config`; `dynamodb:PutItem`, `dynamodb:GetItem`, `dynamodb:UpdateItem`, `dynamodb:Query` on `horde-runs` table; `logs:GetLogEvents` on the log group; `s3:GetObject` on the artifacts bucket.
+- **Scoped IAM for CLI users**: The CDK construct outputs a managed policy ARN. Developers need: `ecs:RunTask`, `ecs:DescribeTasks`, `ecs:StopTask`, `ecs:TagResource` on the cluster; `iam:PassRole` on the horde task role and execution role (e.g., `arn:aws:iam::*:role/horde-*`); `ssm:GetParameter` on `/horde/config`; `dynamodb:PutItem`, `dynamodb:GetItem`, `dynamodb:UpdateItem`, `dynamodb:Query` on `horde-runs` table; `logs:GetLogEvents` on the log group; `s3:GetObject` on the artifacts bucket.
 - **Scoped git token**: Fine-grained GitHub PAT — read + push to `horde/*` branches only. Cannot push to main, cannot delete branches.
 - **API key limits**: Anthropic API key with usage limits set at the key level.
 - **Ephemeral**: Instance is destroyed after the run. No persistent state, no attack surface.

--- a/SPEC.md
+++ b/SPEC.md
@@ -515,7 +515,7 @@ type LaunchResult struct {
 }
 
 type InstanceStatus struct {
-    State      string // running, stopped, unknown
+    State      string // pending, running, stopping, stopped, unknown
     ExitCode   *int   // nil while running
     StartedAt  time.Time
     FinishedAt *time.Time // nil while running

--- a/SPEC.md
+++ b/SPEC.md
@@ -465,7 +465,7 @@ The format is chosen to be:
 ### v0.2 — Baseline
 
 - **Scoped IAM for tasks**: Task role can only write to the artifacts S3 bucket and read specific secrets. No EC2, no other AWS services.
-- **Scoped IAM for CLI users**: The CDK construct outputs a managed policy ARN. Developers need: `ecs:RunTask`, `ecs:DescribeTasks`, `ecs:StopTask`, `ecs:TagResource` on the cluster; `iam:PassRole` on the horde task role and execution role (e.g., `arn:aws:iam::*:role/horde-*`); `ssm:GetParameter` on `/horde/config`; `dynamodb:PutItem`, `dynamodb:GetItem`, `dynamodb:UpdateItem`, `dynamodb:Query` on `horde-runs` table; `logs:GetLogEvents` on the log group; `s3:GetObject` on the artifacts bucket.
+- **Scoped IAM for CLI users**: The CDK construct outputs a managed policy ARN. Developers need: `ecs:RunTask`, `ecs:DescribeTasks`, `ecs:StopTask` on the cluster; `ecs:TagResource` on task resources under the cluster (e.g., `arn:aws:ecs:*:*:task/<cluster>/*`); `iam:PassRole` on the horde task role and execution role (e.g., `arn:aws:iam::*:role/horde-*`); `ssm:GetParameter` on `/horde/config`; `dynamodb:PutItem`, `dynamodb:GetItem`, `dynamodb:UpdateItem`, `dynamodb:Query` on `horde-runs` table; `logs:GetLogEvents` on the log group; `s3:GetObject` on the artifacts bucket.
 - **Scoped git token**: Fine-grained GitHub PAT — read + push to `horde/*` branches only. Cannot push to main, cannot delete branches.
 - **API key limits**: Anthropic API key with usage limits set at the key level.
 - **Ephemeral**: Instance is destroyed after the run. No persistent state, no attack surface.

--- a/SPEC.md
+++ b/SPEC.md
@@ -338,6 +338,7 @@ For the `aws-ecs` provider, all config is discovered from a single SSM parameter
   "subnets": ["subnet-abc", "subnet-def"],
   "security_group": "sg-123",
   "log_group": "/ecs/horde-worker",
+  "log_stream_prefix": "ecs",
   "artifacts_bucket": "my-horde-artifacts",
   "runs_table": "horde-runs",
   "max_concurrent": 5,

--- a/SPEC.md
+++ b/SPEC.md
@@ -465,7 +465,7 @@ The format is chosen to be:
 ### v0.2 — Baseline
 
 - **Scoped IAM for tasks**: Task role can only write to the artifacts S3 bucket and read specific secrets. No EC2, no other AWS services.
-- **Scoped IAM for CLI users**: The CDK construct outputs a managed policy ARN. Developers need: `ecs:RunTask`, `ecs:DescribeTasks`, `ecs:StopTask` on the cluster; `ssm:GetParameter` on `/horde/config`; `dynamodb:PutItem`, `dynamodb:GetItem`, `dynamodb:UpdateItem`, `dynamodb:Query` on `horde-runs` table; `logs:GetLogEvents` on the log group; `s3:GetObject` on the artifacts bucket.
+- **Scoped IAM for CLI users**: The CDK construct outputs a managed policy ARN. Developers need: `ecs:RunTask`, `ecs:DescribeTasks`, `ecs:StopTask`, `ecs:TagResource` on the cluster; `ssm:GetParameter` on `/horde/config`; `dynamodb:PutItem`, `dynamodb:GetItem`, `dynamodb:UpdateItem`, `dynamodb:Query` on `horde-runs` table; `logs:GetLogEvents` on the log group; `s3:GetObject` on the artifacts bucket.
 - **Scoped git token**: Fine-grained GitHub PAT — read + push to `horde/*` branches only. Cannot push to main, cannot delete branches.
 - **API key limits**: Anthropic API key with usage limits set at the key level.
 - **Ephemeral**: Instance is destroyed after the run. No persistent state, no attack surface.

--- a/cmd/horde/factory_test.go
+++ b/cmd/horde/factory_test.go
@@ -43,7 +43,7 @@ func (f *fakeSSMClient) GetParameter(_ context.Context, _ *ssm.GetParameterInput
 }
 
 func validSSMJSON() string {
-	return `{"cluster_arn":"arn:aws:ecs:us-east-1:123456789012:cluster/horde","task_definition_arn":"arn:aws:ecs:us-east-1:123456789012:task-definition/horde-worker:1","subnets":["subnet-abc","subnet-def"],"security_group":"sg-123","log_group":"/ecs/horde-worker","artifacts_bucket":"my-horde-artifacts","runs_table":"horde-runs","max_concurrent":5,"default_timeout_minutes":1440}`
+	return `{"cluster_arn":"arn:aws:ecs:us-east-1:123456789012:cluster/horde","task_definition_arn":"arn:aws:ecs:us-east-1:123456789012:task-definition/horde-worker:1","subnets":["subnet-abc","subnet-def"],"security_group":"sg-123","log_group":"/ecs/horde-worker","log_stream_prefix":"ecs","artifacts_bucket":"my-horde-artifacts","runs_table":"horde-runs","max_concurrent":5,"default_timeout_minutes":1440}`
 }
 
 func TestInitProviderAndStore(t *testing.T) {

--- a/internal/config/ssm.go
+++ b/internal/config/ssm.go
@@ -113,6 +113,7 @@ type HordeConfig struct {
 	Subnets               []string `json:"subnets"`
 	SecurityGroup         string   `json:"security_group"`
 	LogGroup              string   `json:"log_group"`
+	LogStreamPrefix       string   `json:"log_stream_prefix"`
 	ArtifactsBucket       string   `json:"artifacts_bucket"`
 	RunsTable             string   `json:"runs_table"`
 	MaxConcurrent         int      `json:"max_concurrent"`
@@ -136,6 +137,9 @@ func (c *HordeConfig) Validate() error {
 	}
 	if c.LogGroup == "" {
 		missing = append(missing, "log_group")
+	}
+	if c.LogStreamPrefix == "" {
+		missing = append(missing, "log_stream_prefix")
 	}
 	if c.ArtifactsBucket == "" {
 		missing = append(missing, "artifacts_bucket")

--- a/internal/config/ssm_test.go
+++ b/internal/config/ssm_test.go
@@ -21,6 +21,7 @@ func validHordeFields() map[string]interface{} {
 		"subnets":                 []string{"subnet-abc", "subnet-def"},
 		"security_group":          "sg-123",
 		"log_group":               "/ecs/horde-worker",
+		"log_stream_prefix":       "ecs",
 		"artifacts_bucket":        "my-horde-artifacts",
 		"runs_table":              "horde-runs",
 		"max_concurrent":          5,
@@ -223,6 +224,9 @@ func TestParseHordeConfig_Valid(t *testing.T) {
 	if cfg.LogGroup != "/ecs/horde-worker" {
 		t.Errorf("LogGroup = %q, want %q", cfg.LogGroup, "/ecs/horde-worker")
 	}
+	if cfg.LogStreamPrefix != "ecs" {
+		t.Errorf("LogStreamPrefix = %q, want %q", cfg.LogStreamPrefix, "ecs")
+	}
 	if cfg.ArtifactsBucket != "my-horde-artifacts" {
 		t.Errorf("ArtifactsBucket = %q, want %q", cfg.ArtifactsBucket, "my-horde-artifacts")
 	}
@@ -245,6 +249,7 @@ func TestParseHordeConfig_JSONRoundTrip(t *testing.T) {
 		Subnets:               []string{"subnet-abc", "subnet-def"},
 		SecurityGroup:         "sg-123",
 		LogGroup:              "/ecs/horde-worker",
+		LogStreamPrefix:       "ecs",
 		ArtifactsBucket:       "my-horde-artifacts",
 		RunsTable:             "horde-runs",
 		MaxConcurrent:         5,
@@ -260,8 +265,8 @@ func TestParseHordeConfig_JSONRoundTrip(t *testing.T) {
 	}
 	wantKeys := []string{
 		"cluster_arn", "task_definition_arn", "subnets", "security_group",
-		"log_group", "artifacts_bucket", "runs_table", "max_concurrent",
-		"default_timeout_minutes",
+		"log_group", "log_stream_prefix", "artifacts_bucket", "runs_table",
+		"max_concurrent", "default_timeout_minutes",
 	}
 	for _, key := range wantKeys {
 		if _, ok := m[key]; !ok {
@@ -306,6 +311,11 @@ func TestParseHordeConfig_MissingFields(t *testing.T) {
 			name:    "missing log_group",
 			mutate:  func(m map[string]interface{}) { delete(m, "log_group") },
 			wantErr: []string{"missing required fields: log_group"},
+		},
+		{
+			name:    "missing log_stream_prefix",
+			mutate:  func(m map[string]interface{}) { delete(m, "log_stream_prefix") },
+			wantErr: []string{"missing required fields: log_stream_prefix"},
 		},
 		{
 			name:    "missing artifacts_bucket",
@@ -472,6 +482,7 @@ func TestHordeConfig_Validate_AllFieldsPresent(t *testing.T) {
 		Subnets:               []string{"subnet-abc"},
 		SecurityGroup:         "sg-123",
 		LogGroup:              "/ecs/horde-worker",
+		LogStreamPrefix:       "ecs",
 		ArtifactsBucket:       "my-bucket",
 		RunsTable:             "horde-runs",
 		MaxConcurrent:         1,

--- a/internal/provider/docker.go
+++ b/internal/provider/docker.go
@@ -322,7 +322,7 @@ func (p *DockerProvider) ReadFile(ctx context.Context, opts ReadFileOpts) ([]byt
 	data, err := os.ReadFile(fullPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("reading file: %s not found in results for run %s", opts.Path, opts.RunID)
+			return nil, &FileNotFoundError{Path: opts.Path, Err: err}
 		}
 		return nil, fmt.Errorf("reading file: %w", err)
 	}

--- a/internal/provider/docker_test.go
+++ b/internal/provider/docker_test.go
@@ -1013,8 +1013,12 @@ func TestDockerProvider_ReadFile_FileNotFound(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
-	if !strings.Contains(err.Error(), "not found in results for run") {
-		t.Errorf("expected error to contain %q, got: %v", "not found in results for run", err)
+	var notFound *FileNotFoundError
+	if !errors.As(err, &notFound) {
+		t.Errorf("ReadFile() error type = %T, want *FileNotFoundError", err)
+	}
+	if notFound.Path != ".orc/audit/missing.json" {
+		t.Errorf("FileNotFoundError.Path = %q, want %q", notFound.Path, ".orc/audit/missing.json")
 	}
 }
 
@@ -1122,10 +1126,11 @@ func TestDockerProvider_ReadFile_ReadError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
-	if strings.Contains(err.Error(), "not found in results for run") {
-		t.Errorf("expected a read error, not a not-found error, got: %v", err)
-	}
 	if !strings.Contains(err.Error(), "reading file:") {
 		t.Errorf("expected error to contain %q, got: %v", "reading file:", err)
+	}
+	var notFound *FileNotFoundError
+	if errors.As(err, &notFound) {
+		t.Errorf("ReadFile() error = %T, should NOT be *FileNotFoundError", err)
 	}
 }

--- a/internal/provider/ecs.go
+++ b/internal/provider/ecs.go
@@ -2,10 +2,13 @@ package provider
 
 import (
 	"context"
+	"fmt"
+	"io"
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/jorge-barreto/horde/internal/config"
 )
 
 // ECSClient is the subset of the ECS API used by ECSProvider.
@@ -23,4 +26,44 @@ type CloudWatchLogsClient interface {
 // S3Client is the subset of the S3 API used by ECSProvider.
 type S3Client interface {
 	GetObject(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+}
+
+// ECSProvider implements Provider using AWS ECS Fargate.
+type ECSProvider struct {
+	ecs    ECSClient
+	logs   CloudWatchLogsClient
+	s3     S3Client
+	config *config.HordeConfig
+}
+
+// NewECSProvider constructs an ECSProvider with the given AWS clients and config.
+func NewECSProvider(ecsClient ECSClient, logsClient CloudWatchLogsClient, s3Client S3Client, cfg *config.HordeConfig) *ECSProvider {
+	return &ECSProvider{
+		ecs:    ecsClient,
+		logs:   logsClient,
+		s3:     s3Client,
+		config: cfg,
+	}
+}
+
+var _ Provider = (*ECSProvider)(nil)
+
+func (p *ECSProvider) Launch(ctx context.Context, opts LaunchOpts) (*LaunchResult, error) {
+	return nil, fmt.Errorf("ECSProvider.Launch not implemented")
+}
+
+func (p *ECSProvider) Status(ctx context.Context, instanceID string) (*InstanceStatus, error) {
+	return nil, fmt.Errorf("ECSProvider.Status not implemented")
+}
+
+func (p *ECSProvider) Logs(ctx context.Context, instanceID string, follow bool) (io.ReadCloser, error) {
+	return nil, fmt.Errorf("ECSProvider.Logs not implemented")
+}
+
+func (p *ECSProvider) Stop(ctx context.Context, opts StopOpts) error {
+	return fmt.Errorf("ECSProvider.Stop not implemented")
+}
+
+func (p *ECSProvider) ReadFile(ctx context.Context, opts ReadFileOpts) ([]byte, error) {
+	return nil, fmt.Errorf("ECSProvider.ReadFile not implemented")
 }

--- a/internal/provider/ecs.go
+++ b/internal/provider/ecs.go
@@ -368,6 +368,9 @@ func (p *ECSProvider) ReadFile(ctx context.Context, opts ReadFileOpts) ([]byte, 
 		}
 		return nil, fmt.Errorf("reading file from s3: %w", err)
 	}
+	if out == nil || out.Body == nil {
+		return nil, fmt.Errorf("reading file from s3: nil response")
+	}
 	defer out.Body.Close()
 
 	data, err := io.ReadAll(out.Body)

--- a/internal/provider/ecs.go
+++ b/internal/provider/ecs.go
@@ -425,6 +425,9 @@ func (p *ECSProvider) ReadFile(ctx context.Context, opts ReadFileOpts) ([]byte, 
 	if opts.RunID == "" {
 		return nil, fmt.Errorf("reading file: run ID is required")
 	}
+	if strings.ContainsAny(opts.RunID, "/\\") || strings.Contains(opts.RunID, "..") {
+		return nil, fmt.Errorf("reading file: invalid run ID")
+	}
 	if opts.Path == "" {
 		return nil, fmt.Errorf("reading file: path is required")
 	}

--- a/internal/provider/ecs.go
+++ b/internal/provider/ecs.go
@@ -182,8 +182,12 @@ func (p *ECSProvider) Status(ctx context.Context, instanceID string) (*InstanceS
 	state := "unknown"
 	if task.LastStatus != nil {
 		switch *task.LastStatus {
+		case "PROVISIONING", "PENDING", "ACTIVATING":
+			state = "pending"
 		case "RUNNING":
 			state = "running"
+		case "DEPROVISIONING", "STOPPING":
+			state = "stopping"
 		case "STOPPED":
 			state = "stopped"
 		}

--- a/internal/provider/ecs.go
+++ b/internal/provider/ecs.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	cwltypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -284,6 +285,17 @@ func (p *ECSProvider) Logs(ctx context.Context, instanceID string, follow bool) 
 
 			out, err := p.logs.GetLogEvents(followCtx, input)
 			if err != nil {
+				var rnf *cwltypes.ResourceNotFoundException
+				if errors.As(err, &rnf) {
+					// Log stream not created yet — container hasn't started writing output.
+					// Wait and retry instead of treating as fatal.
+					select {
+					case <-followCtx.Done():
+						return
+					case <-time.After(interval):
+						continue
+					}
+				}
 				pw.CloseWithError(fmt.Errorf("reading logs: %w", err))
 				return
 			}

--- a/internal/provider/ecs.go
+++ b/internal/provider/ecs.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -13,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/jorge-barreto/horde/internal/config"
 )
 
@@ -329,5 +331,45 @@ func (p *ECSProvider) Stop(ctx context.Context, opts StopOpts) error {
 }
 
 func (p *ECSProvider) ReadFile(ctx context.Context, opts ReadFileOpts) ([]byte, error) {
-	return nil, fmt.Errorf("ECSProvider.ReadFile not implemented")
+	if opts.Path == "" {
+		return nil, fmt.Errorf("reading file: path is required")
+	}
+
+	const orcPrefix = ".orc/"
+	if !strings.HasPrefix(opts.Path, orcPrefix) {
+		return nil, fmt.Errorf("reading file: path must start with %q", orcPrefix)
+	}
+	relPath := strings.TrimPrefix(opts.Path, orcPrefix)
+	if relPath == "" {
+		return nil, fmt.Errorf("reading file: path must include a filename after %q", orcPrefix)
+	}
+
+	bucket := ""
+	if opts.Metadata != nil {
+		bucket = opts.Metadata["artifacts_bucket"]
+	}
+	if bucket == "" {
+		return nil, fmt.Errorf("reading file: artifacts_bucket not found in metadata")
+	}
+
+	key := "horde-runs/" + opts.RunID + "/" + relPath
+
+	out, err := p.s3.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		var noSuchKey *s3types.NoSuchKey
+		if errors.As(err, &noSuchKey) {
+			return nil, &FileNotFoundError{Path: opts.Path, Err: err}
+		}
+		return nil, fmt.Errorf("reading file from s3: %w", err)
+	}
+	defer out.Body.Close()
+
+	data, err := io.ReadAll(out.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading file from s3: %w", err)
+	}
+	return data, nil
 }

--- a/internal/provider/ecs.go
+++ b/internal/provider/ecs.go
@@ -127,7 +127,60 @@ func (p *ECSProvider) Launch(ctx context.Context, opts LaunchOpts) (*LaunchResul
 }
 
 func (p *ECSProvider) Status(ctx context.Context, instanceID string) (*InstanceStatus, error) {
-	return nil, fmt.Errorf("ECSProvider.Status not implemented")
+	out, err := p.ecs.DescribeTasks(ctx, &ecs.DescribeTasksInput{
+		Cluster: aws.String(p.config.ClusterARN),
+		Tasks:   []string{instanceID},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("describing ECS task: %w", err)
+	}
+	if out == nil {
+		return nil, fmt.Errorf("describing ECS task: nil response")
+	}
+
+	if len(out.Failures) > 0 {
+		f := out.Failures[0]
+		reason := ""
+		if f.Reason != nil {
+			reason = *f.Reason
+		}
+		return nil, fmt.Errorf("describing ECS task: %s", reason)
+	}
+
+	if len(out.Tasks) == 0 {
+		return nil, fmt.Errorf("describing ECS task: task not found")
+	}
+
+	task := out.Tasks[0]
+
+	state := "unknown"
+	if task.LastStatus != nil {
+		switch *task.LastStatus {
+		case "RUNNING":
+			state = "running"
+		case "STOPPED":
+			state = "stopped"
+		}
+	}
+
+	status := &InstanceStatus{
+		State: state,
+	}
+
+	if task.StartedAt != nil {
+		status.StartedAt = *task.StartedAt
+	}
+
+	if task.StoppedAt != nil {
+		status.FinishedAt = task.StoppedAt
+	}
+
+	if len(task.Containers) > 0 && task.Containers[0].ExitCode != nil {
+		exitCode := int(*task.Containers[0].ExitCode)
+		status.ExitCode = &exitCode
+	}
+
+	return status, nil
 }
 
 func (p *ECSProvider) Logs(ctx context.Context, instanceID string, follow bool) (io.ReadCloser, error) {

--- a/internal/provider/ecs.go
+++ b/internal/provider/ecs.go
@@ -317,7 +317,15 @@ func (p *ECSProvider) Logs(ctx context.Context, instanceID string, follow bool) 
 }
 
 func (p *ECSProvider) Stop(ctx context.Context, opts StopOpts) error {
-	return fmt.Errorf("ECSProvider.Stop not implemented")
+	_, err := p.ecs.StopTask(ctx, &ecs.StopTaskInput{
+		Cluster: aws.String(p.config.ClusterARN),
+		Task:    aws.String(opts.InstanceID),
+		Reason:  aws.String("horde kill"),
+	})
+	if err != nil {
+		return fmt.Errorf("stopping ECS task: %w", err)
+	}
+	return nil
 }
 
 func (p *ECSProvider) ReadFile(ctx context.Context, opts ReadFileOpts) ([]byte, error) {

--- a/internal/provider/ecs.go
+++ b/internal/provider/ecs.go
@@ -5,11 +5,17 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/jorge-barreto/horde/internal/config"
 )
+
+// containerName is the container name in the ECS task definition.
+// Must match the name set by the @horde/cdk construct.
+const containerName = "horde-worker"
 
 // ECSClient is the subset of the ECS API used by ECSProvider.
 type ECSClient interface {
@@ -49,7 +55,75 @@ func NewECSProvider(ecsClient ECSClient, logsClient CloudWatchLogsClient, s3Clie
 var _ Provider = (*ECSProvider)(nil)
 
 func (p *ECSProvider) Launch(ctx context.Context, opts LaunchOpts) (*LaunchResult, error) {
-	return nil, fmt.Errorf("ECSProvider.Launch not implemented")
+	env := []ecstypes.KeyValuePair{
+		{Name: aws.String("REPO_URL"), Value: aws.String(opts.Repo)},
+		{Name: aws.String("TICKET"), Value: aws.String(opts.Ticket)},
+		{Name: aws.String("BRANCH"), Value: aws.String(opts.Branch)},
+		{Name: aws.String("WORKFLOW"), Value: aws.String(opts.Workflow)},
+		{Name: aws.String("RUN_ID"), Value: aws.String(opts.RunID)},
+		{Name: aws.String("ARTIFACTS_BUCKET"), Value: aws.String(p.config.ArtifactsBucket)},
+	}
+
+	input := &ecs.RunTaskInput{
+		TaskDefinition: aws.String(p.config.TaskDefinitionARN),
+		Cluster:        aws.String(p.config.ClusterARN),
+		LaunchType:     ecstypes.LaunchTypeFargate,
+		Count:          aws.Int32(1),
+		NetworkConfiguration: &ecstypes.NetworkConfiguration{
+			AwsvpcConfiguration: &ecstypes.AwsVpcConfiguration{
+				Subnets:        p.config.Subnets,
+				SecurityGroups: []string{p.config.SecurityGroup},
+				AssignPublicIp: ecstypes.AssignPublicIpEnabled,
+			},
+		},
+		Overrides: &ecstypes.TaskOverride{
+			ContainerOverrides: []ecstypes.ContainerOverride{
+				{
+					Name:        aws.String(containerName),
+					Environment: env,
+				},
+			},
+		},
+		Tags: []ecstypes.Tag{
+			{Key: aws.String("horde-run-id"), Value: aws.String(opts.RunID)},
+			{Key: aws.String("horde-ticket"), Value: aws.String(opts.Ticket)},
+		},
+	}
+
+	out, err := p.ecs.RunTask(ctx, input)
+	if err != nil {
+		return nil, fmt.Errorf("launching ECS task: %w", err)
+	}
+	if out == nil {
+		return nil, fmt.Errorf("launching ECS task: nil response")
+	}
+
+	if len(out.Failures) > 0 {
+		f := out.Failures[0]
+		reason := ""
+		if f.Reason != nil {
+			reason = *f.Reason
+		}
+		return nil, fmt.Errorf("launching ECS task: %s", reason)
+	}
+
+	if len(out.Tasks) == 0 {
+		return nil, fmt.Errorf("launching ECS task: no task returned")
+	}
+
+	task := out.Tasks[0]
+	if task.TaskArn == nil {
+		return nil, fmt.Errorf("launching ECS task: task ARN is nil")
+	}
+
+	return &LaunchResult{
+		InstanceID: *task.TaskArn,
+		Metadata: map[string]string{
+			"cluster_arn":      p.config.ClusterARN,
+			"log_group":        p.config.LogGroup,
+			"artifacts_bucket": p.config.ArtifactsBucket,
+		},
+	}, nil
 }
 
 func (p *ECSProvider) Status(ctx context.Context, instanceID string) (*InstanceStatus, error) {

--- a/internal/provider/ecs.go
+++ b/internal/provider/ecs.go
@@ -338,7 +338,41 @@ func (p *ECSProvider) Logs(ctx context.Context, instanceID string, follow bool) 
 				}
 				if taskOut != nil && len(taskOut.Tasks) > 0 {
 					if taskOut.Tasks[0].LastStatus != nil && *taskOut.Tasks[0].LastStatus == "STOPPED" {
-						return
+						// Final drain: CloudWatch ingestion can lag task
+						// termination by several seconds. Fetch remaining
+						// events until NextForwardToken stops changing.
+						for {
+							drainInput := &cloudwatchlogs.GetLogEventsInput{
+								LogGroupName:  aws.String(p.config.LogGroup),
+								LogStreamName: aws.String(logStream),
+								StartFromHead: aws.Bool(true),
+							}
+							if nextToken != nil {
+								drainInput.NextToken = nextToken
+							}
+							drainOut, drainErr := p.logs.GetLogEvents(followCtx, drainInput)
+							if drainErr != nil {
+								return
+							}
+							if drainOut == nil {
+								return
+							}
+							for _, event := range drainOut.Events {
+								if event.Message != nil {
+									msg := *event.Message
+									if !strings.HasSuffix(msg, "\n") {
+										msg += "\n"
+									}
+									if _, err := io.WriteString(pw, msg); err != nil {
+										return
+									}
+								}
+							}
+							if drainOut.NextForwardToken == nil || (nextToken != nil && *drainOut.NextForwardToken == *nextToken) {
+								return
+							}
+							nextToken = drainOut.NextForwardToken
+						}
 					}
 				}
 			}

--- a/internal/provider/ecs.go
+++ b/internal/provider/ecs.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
@@ -38,10 +39,11 @@ type S3Client interface {
 
 // ECSProvider implements Provider using AWS ECS Fargate.
 type ECSProvider struct {
-	ecs    ECSClient
-	logs   CloudWatchLogsClient
-	s3     S3Client
-	config *config.HordeConfig
+	ecs          ECSClient
+	logs         CloudWatchLogsClient
+	s3           S3Client
+	config       *config.HordeConfig
+	pollInterval time.Duration
 }
 
 // NewECSProvider constructs an ECSProvider with the given AWS clients and config.
@@ -55,6 +57,21 @@ func NewECSProvider(ecsClient ECSClient, logsClient CloudWatchLogsClient, s3Clie
 }
 
 var _ Provider = (*ECSProvider)(nil)
+
+// ecsLogFollower wraps a pipe reader for CloudWatch follow mode.
+// Closing cancels the polling goroutine and waits for it to exit.
+type ecsLogFollower struct {
+	*io.PipeReader
+	cancel context.CancelFunc
+	done   <-chan struct{}
+}
+
+func (f *ecsLogFollower) Close() error {
+	f.cancel()
+	err := f.PipeReader.Close()
+	<-f.done
+	return err
+}
 
 func (p *ECSProvider) Launch(ctx context.Context, opts LaunchOpts) (*LaunchResult, error) {
 	env := []ecstypes.KeyValuePair{
@@ -186,10 +203,6 @@ func (p *ECSProvider) Status(ctx context.Context, instanceID string) (*InstanceS
 }
 
 func (p *ECSProvider) Logs(ctx context.Context, instanceID string, follow bool) (io.ReadCloser, error) {
-	if follow {
-		return nil, fmt.Errorf("ECSProvider.Logs follow mode not implemented")
-	}
-
 	taskID := instanceID
 	if i := strings.LastIndex(instanceID, "/"); i >= 0 {
 		taskID = instanceID[i+1:]
@@ -200,39 +213,107 @@ func (p *ECSProvider) Logs(ctx context.Context, instanceID string, follow bool) 
 
 	logStream := p.config.LogStreamPrefix + "/" + containerName + "/" + taskID
 
-	var buf bytes.Buffer
-	var nextToken *string
-	for {
-		input := &cloudwatchlogs.GetLogEventsInput{
-			LogGroupName:  aws.String(p.config.LogGroup),
-			LogStreamName: aws.String(logStream),
-			StartFromHead: aws.Bool(true),
-		}
-		if nextToken != nil {
-			input.NextToken = nextToken
-		}
+	if !follow {
+		var buf bytes.Buffer
+		var nextToken *string
+		for {
+			input := &cloudwatchlogs.GetLogEventsInput{
+				LogGroupName:  aws.String(p.config.LogGroup),
+				LogStreamName: aws.String(logStream),
+				StartFromHead: aws.Bool(true),
+			}
+			if nextToken != nil {
+				input.NextToken = nextToken
+			}
 
-		out, err := p.logs.GetLogEvents(ctx, input)
-		if err != nil {
-			return nil, fmt.Errorf("reading logs: %w", err)
-		}
+			out, err := p.logs.GetLogEvents(ctx, input)
+			if err != nil {
+				return nil, fmt.Errorf("reading logs: %w", err)
+			}
 
-		for _, event := range out.Events {
-			if event.Message != nil {
-				buf.WriteString(*event.Message)
-				if !strings.HasSuffix(*event.Message, "\n") {
-					buf.WriteByte('\n')
+			for _, event := range out.Events {
+				if event.Message != nil {
+					buf.WriteString(*event.Message)
+					if !strings.HasSuffix(*event.Message, "\n") {
+						buf.WriteByte('\n')
+					}
 				}
 			}
-		}
 
-		if out.NextForwardToken == nil || (nextToken != nil && *out.NextForwardToken == *nextToken) {
-			break
+			if out.NextForwardToken == nil || (nextToken != nil && *out.NextForwardToken == *nextToken) {
+				break
+			}
+			nextToken = out.NextForwardToken
 		}
-		nextToken = out.NextForwardToken
+		return io.NopCloser(&buf), nil
 	}
 
-	return io.NopCloser(&buf), nil
+	pr, pw := io.Pipe()
+	followCtx, cancel := context.WithCancel(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer pw.Close()
+
+		interval := p.pollInterval
+		if interval == 0 {
+			interval = time.Second
+		}
+
+		var nextToken *string
+		for {
+			input := &cloudwatchlogs.GetLogEventsInput{
+				LogGroupName:  aws.String(p.config.LogGroup),
+				LogStreamName: aws.String(logStream),
+				StartFromHead: aws.Bool(true),
+			}
+			if nextToken != nil {
+				input.NextToken = nextToken
+			}
+
+			out, err := p.logs.GetLogEvents(followCtx, input)
+			if err != nil {
+				pw.CloseWithError(fmt.Errorf("reading logs: %w", err))
+				return
+			}
+
+			for _, event := range out.Events {
+				if event.Message != nil {
+					msg := *event.Message
+					if !strings.HasSuffix(msg, "\n") {
+						msg += "\n"
+					}
+					if _, err := io.WriteString(pw, msg); err != nil {
+						return
+					}
+				}
+			}
+
+			if out.NextForwardToken != nil {
+				nextToken = out.NextForwardToken
+			}
+
+			// Check if task has stopped.
+			taskOut, err := p.ecs.DescribeTasks(followCtx, &ecs.DescribeTasksInput{
+				Cluster: aws.String(p.config.ClusterARN),
+				Tasks:   []string{instanceID},
+			})
+			if err == nil && taskOut != nil && len(taskOut.Tasks) > 0 {
+				if taskOut.Tasks[0].LastStatus != nil && *taskOut.Tasks[0].LastStatus == "STOPPED" {
+					return
+				}
+			}
+
+			select {
+			case <-followCtx.Done():
+				return
+			case <-time.After(interval):
+			}
+		}
+	}()
+
+	return &ecsLogFollower{PipeReader: pr, cancel: cancel, done: done}, nil
 }
 
 func (p *ECSProvider) Stop(ctx context.Context, opts StopOpts) error {

--- a/internal/provider/ecs.go
+++ b/internal/provider/ecs.go
@@ -314,6 +314,15 @@ func (p *ECSProvider) Logs(ctx context.Context, instanceID string, follow bool) 
 				}
 			} else {
 				describeFailures = 0
+				if taskOut != nil && len(taskOut.Failures) > 0 {
+					reason := ""
+					f := taskOut.Failures[0]
+					if f.Reason != nil {
+						reason = *f.Reason
+					}
+					fmt.Fprintf(pw, "WARNING: task no longer available: %s\n", reason)
+					return
+				}
 				if taskOut != nil && len(taskOut.Tasks) > 0 {
 					if taskOut.Tasks[0].LastStatus != nil && *taskOut.Tasks[0].LastStatus == "STOPPED" {
 						return

--- a/internal/provider/ecs.go
+++ b/internal/provider/ecs.go
@@ -352,7 +352,22 @@ func (p *ECSProvider) Logs(ctx context.Context, instanceID string, follow bool) 
 							}
 							drainOut, drainErr := p.logs.GetLogEvents(followCtx, drainInput)
 							if drainErr != nil {
-								return
+								var rnf *cwltypes.ResourceNotFoundException
+								if errors.As(drainErr, &rnf) {
+									return // stream gone — nothing more to drain
+								}
+								// Transient error — retry once after a short backoff.
+								select {
+								case <-followCtx.Done():
+									return
+								case <-time.After(interval):
+								}
+								drainOut, drainErr = p.logs.GetLogEvents(followCtx, drainInput)
+								if drainErr != nil {
+									fmt.Fprintf(pw, "WARNING: output may be incomplete: %v\n", drainErr)
+									pw.CloseWithError(fmt.Errorf("reading logs: %w", drainErr))
+									return
+								}
 							}
 							if drainOut == nil {
 								return

--- a/internal/provider/ecs.go
+++ b/internal/provider/ecs.go
@@ -331,6 +331,9 @@ func (p *ECSProvider) Stop(ctx context.Context, opts StopOpts) error {
 }
 
 func (p *ECSProvider) ReadFile(ctx context.Context, opts ReadFileOpts) ([]byte, error) {
+	if opts.RunID == "" {
+		return nil, fmt.Errorf("reading file: run ID is required")
+	}
 	if opts.Path == "" {
 		return nil, fmt.Errorf("reading file: path is required")
 	}

--- a/internal/provider/ecs.go
+++ b/internal/provider/ecs.go
@@ -1,0 +1,26 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+// ECSClient is the subset of the ECS API used by ECSProvider.
+type ECSClient interface {
+	RunTask(ctx context.Context, params *ecs.RunTaskInput, optFns ...func(*ecs.Options)) (*ecs.RunTaskOutput, error)
+	DescribeTasks(ctx context.Context, params *ecs.DescribeTasksInput, optFns ...func(*ecs.Options)) (*ecs.DescribeTasksOutput, error)
+	StopTask(ctx context.Context, params *ecs.StopTaskInput, optFns ...func(*ecs.Options)) (*ecs.StopTaskOutput, error)
+}
+
+// CloudWatchLogsClient is the subset of the CloudWatch Logs API used by ECSProvider.
+type CloudWatchLogsClient interface {
+	GetLogEvents(ctx context.Context, params *cloudwatchlogs.GetLogEventsInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.GetLogEventsOutput, error)
+}
+
+// S3Client is the subset of the S3 API used by ECSProvider.
+type S3Client interface {
+	GetObject(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+}

--- a/internal/provider/ecs.go
+++ b/internal/provider/ecs.go
@@ -236,6 +236,9 @@ func (p *ECSProvider) Logs(ctx context.Context, instanceID string, follow bool) 
 			if err != nil {
 				return nil, fmt.Errorf("reading logs: %w", err)
 			}
+			if out == nil {
+				return nil, fmt.Errorf("reading logs: nil response")
+			}
 
 			for _, event := range out.Events {
 				if event.Message != nil {
@@ -282,6 +285,10 @@ func (p *ECSProvider) Logs(ctx context.Context, instanceID string, follow bool) 
 			out, err := p.logs.GetLogEvents(followCtx, input)
 			if err != nil {
 				pw.CloseWithError(fmt.Errorf("reading logs: %w", err))
+				return
+			}
+			if out == nil {
+				pw.CloseWithError(fmt.Errorf("reading logs: nil response"))
 				return
 			}
 

--- a/internal/provider/ecs.go
+++ b/internal/provider/ecs.go
@@ -1,9 +1,11 @@
 package provider
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
@@ -184,7 +186,53 @@ func (p *ECSProvider) Status(ctx context.Context, instanceID string) (*InstanceS
 }
 
 func (p *ECSProvider) Logs(ctx context.Context, instanceID string, follow bool) (io.ReadCloser, error) {
-	return nil, fmt.Errorf("ECSProvider.Logs not implemented")
+	if follow {
+		return nil, fmt.Errorf("ECSProvider.Logs follow mode not implemented")
+	}
+
+	taskID := instanceID
+	if i := strings.LastIndex(instanceID, "/"); i >= 0 {
+		taskID = instanceID[i+1:]
+	}
+	if taskID == "" {
+		return nil, fmt.Errorf("reading logs: empty task ID from instance %q", instanceID)
+	}
+
+	logStream := p.config.LogStreamPrefix + "/" + containerName + "/" + taskID
+
+	var buf bytes.Buffer
+	var nextToken *string
+	for {
+		input := &cloudwatchlogs.GetLogEventsInput{
+			LogGroupName:  aws.String(p.config.LogGroup),
+			LogStreamName: aws.String(logStream),
+			StartFromHead: aws.Bool(true),
+		}
+		if nextToken != nil {
+			input.NextToken = nextToken
+		}
+
+		out, err := p.logs.GetLogEvents(ctx, input)
+		if err != nil {
+			return nil, fmt.Errorf("reading logs: %w", err)
+		}
+
+		for _, event := range out.Events {
+			if event.Message != nil {
+				buf.WriteString(*event.Message)
+				if !strings.HasSuffix(*event.Message, "\n") {
+					buf.WriteByte('\n')
+				}
+			}
+		}
+
+		if out.NextForwardToken == nil || (nextToken != nil && *out.NextForwardToken == *nextToken) {
+			break
+		}
+		nextToken = out.NextForwardToken
+	}
+
+	return io.NopCloser(&buf), nil
 }
 
 func (p *ECSProvider) Stop(ctx context.Context, opts StopOpts) error {

--- a/internal/provider/ecs.go
+++ b/internal/provider/ecs.go
@@ -22,6 +22,10 @@ import (
 // Must match the name set by the @horde/cdk construct.
 const containerName = "horde-worker"
 
+// maxConsecutiveDescribeFailures is the number of consecutive DescribeTasks
+// errors tolerated in follow mode before stopping the log poll loop.
+const maxConsecutiveDescribeFailures = 5
+
 // ECSClient is the subset of the ECS API used by ECSProvider.
 type ECSClient interface {
 	RunTask(ctx context.Context, params *ecs.RunTaskInput, optFns ...func(*ecs.Options)) (*ecs.RunTaskOutput, error)
@@ -264,6 +268,7 @@ func (p *ECSProvider) Logs(ctx context.Context, instanceID string, follow bool) 
 		}
 
 		var nextToken *string
+		var describeFailures int
 		for {
 			input := &cloudwatchlogs.GetLogEventsInput{
 				LogGroupName:  aws.String(p.config.LogGroup),
@@ -301,9 +306,18 @@ func (p *ECSProvider) Logs(ctx context.Context, instanceID string, follow bool) 
 				Cluster: aws.String(p.config.ClusterARN),
 				Tasks:   []string{instanceID},
 			})
-			if err == nil && taskOut != nil && len(taskOut.Tasks) > 0 {
-				if taskOut.Tasks[0].LastStatus != nil && *taskOut.Tasks[0].LastStatus == "STOPPED" {
+			if err != nil {
+				describeFailures++
+				if describeFailures >= maxConsecutiveDescribeFailures {
+					fmt.Fprintf(pw, "WARNING: unable to determine task completion after %d consecutive failures, stopping follow\n", describeFailures)
 					return
+				}
+			} else {
+				describeFailures = 0
+				if taskOut != nil && len(taskOut.Tasks) > 0 {
+					if taskOut.Tasks[0].LastStatus != nil && *taskOut.Tasks[0].LastStatus == "STOPPED" {
+						return
+					}
 				}
 			}
 

--- a/internal/provider/ecs.go
+++ b/internal/provider/ecs.go
@@ -325,6 +325,12 @@ func (p *ECSProvider) Stop(ctx context.Context, opts StopOpts) error {
 		Reason:  aws.String("horde kill"),
 	})
 	if err != nil {
+		// StopTask returns InvalidParameterException when the task is already stopped.
+		// Treat as success for idempotency — the desired state (task stopped) is achieved.
+		var ipe *ecstypes.InvalidParameterException
+		if errors.As(err, &ipe) && strings.Contains(strings.ToLower(ipe.ErrorMessage()), "already stopped") {
+			return nil
+		}
 		return fmt.Errorf("stopping ECS task: %w", err)
 	}
 	return nil

--- a/internal/provider/ecs.go
+++ b/internal/provider/ecs.go
@@ -286,38 +286,32 @@ func (p *ECSProvider) Logs(ctx context.Context, instanceID string, follow bool) 
 			out, err := p.logs.GetLogEvents(followCtx, input)
 			if err != nil {
 				var rnf *cwltypes.ResourceNotFoundException
-				if errors.As(err, &rnf) {
-					// Log stream not created yet — container hasn't started writing output.
-					// Wait and retry instead of treating as fatal.
-					select {
-					case <-followCtx.Done():
-						return
-					case <-time.After(interval):
-						continue
-					}
+				if !errors.As(err, &rnf) {
+					pw.CloseWithError(fmt.Errorf("reading logs: %w", err))
+					return
 				}
-				pw.CloseWithError(fmt.Errorf("reading logs: %w", err))
-				return
-			}
-			if out == nil {
+				// ResourceNotFoundException: log stream not created yet — container
+				// hasn't started writing output. Fall through to DescribeTasks check
+				// so we detect task termination even when no log stream is ever created.
+			} else if out == nil {
 				pw.CloseWithError(fmt.Errorf("reading logs: nil response"))
 				return
-			}
-
-			for _, event := range out.Events {
-				if event.Message != nil {
-					msg := *event.Message
-					if !strings.HasSuffix(msg, "\n") {
-						msg += "\n"
-					}
-					if _, err := io.WriteString(pw, msg); err != nil {
-						return
+			} else {
+				for _, event := range out.Events {
+					if event.Message != nil {
+						msg := *event.Message
+						if !strings.HasSuffix(msg, "\n") {
+							msg += "\n"
+						}
+						if _, err := io.WriteString(pw, msg); err != nil {
+							return
+						}
 					}
 				}
-			}
 
-			if out.NextForwardToken != nil {
-				nextToken = out.NextForwardToken
+				if out.NextForwardToken != nil {
+					nextToken = out.NextForwardToken
+				}
 			}
 
 			// Check if task has stopped.

--- a/internal/provider/ecs_test.go
+++ b/internal/provider/ecs_test.go
@@ -1131,8 +1131,22 @@ func TestECSProvider_Stop_AlreadyStopped(t *testing.T) {
 	err := p.Stop(context.Background(), StopOpts{
 		InstanceID: "arn:aws:ecs:us-east-1:123456789012:task/horde/abc123",
 	})
+	if err != nil {
+		t.Fatalf("Stop() error = %v, want nil (already-stopped tasks should be treated as success)", err)
+	}
+}
+
+func TestECSProvider_Stop_OtherInvalidParameterException(t *testing.T) {
+	t.Parallel()
+	fake := &fakeECSClient{
+		stopTaskErr: &ecstypes.InvalidParameterException{Message: aws.String("some other parameter error")},
+	}
+	p := NewECSProvider(fake, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	err := p.Stop(context.Background(), StopOpts{
+		InstanceID: "arn:aws:ecs:us-east-1:123456789012:task/horde/abc123",
+	})
 	if err == nil {
-		t.Fatal("Stop() error = nil, want non-nil")
+		t.Fatal("Stop() error = nil, want non-nil for non-already-stopped InvalidParameterException")
 	}
 	if !strings.Contains(err.Error(), "stopping ECS task") {
 		t.Errorf("error = %q, want it to contain \"stopping ECS task\"", err.Error())

--- a/internal/provider/ecs_test.go
+++ b/internal/provider/ecs_test.go
@@ -93,6 +93,10 @@ func (f *fakeCloudWatchLogsClient) GetLogEvents(ctx context.Context, params *clo
 	return &cloudwatchlogs.GetLogEventsOutput{}, nil
 }
 
+type failReader struct{ err error }
+
+func (f *failReader) Read(p []byte) (int, error) { return 0, f.err }
+
 type fakeS3Client struct {
 	getObjectInput  *s3.GetObjectInput
 	getObjectOutput *s3.GetObjectOutput
@@ -1220,6 +1224,31 @@ func TestECSProvider_ReadFile_S3Error(t *testing.T) {
 	t.Parallel()
 	fake := &fakeS3Client{
 		getObjectErr: fmt.Errorf("AccessDenied"),
+	}
+	p := NewECSProvider(&fakeECSClient{}, &fakeCloudWatchLogsClient{}, fake, testHordeConfig())
+	_, err := p.ReadFile(context.Background(), ReadFileOpts{
+		RunID:    "run-001",
+		Path:     ".orc/audit/foo.json",
+		Metadata: map[string]string{"artifacts_bucket": "my-horde-artifacts"},
+	})
+	if err == nil {
+		t.Fatal("ReadFile() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "reading file from s3") {
+		t.Errorf("ReadFile() error = %q, want it to contain \"reading file from s3\"", err.Error())
+	}
+	var notFound *FileNotFoundError
+	if errors.As(err, &notFound) {
+		t.Errorf("ReadFile() error = %T, should NOT be *FileNotFoundError", err)
+	}
+}
+
+func TestECSProvider_ReadFile_BodyReadError(t *testing.T) {
+	t.Parallel()
+	fake := &fakeS3Client{
+		getObjectOutput: &s3.GetObjectOutput{
+			Body: io.NopCloser(&failReader{err: fmt.Errorf("connection reset")}),
+		},
 	}
 	p := NewECSProvider(&fakeECSClient{}, &fakeCloudWatchLogsClient{}, fake, testHordeConfig())
 	_, err := p.ReadFile(context.Background(), ReadFileOpts{

--- a/internal/provider/ecs_test.go
+++ b/internal/provider/ecs_test.go
@@ -783,8 +783,47 @@ func TestECSProvider_Logs_LogStreamNotCreated(t *testing.T) {
 
 func TestECSProvider_Logs_Follow_LogStreamNotCreated(t *testing.T) {
 	t.Parallel()
+	rnf := &cwltypes.ResourceNotFoundException{Message: aws.String("The specified log stream does not exist.")}
 	fakeLogs := &fakeCloudWatchLogsClient{
-		getLogEventsErr: &cwltypes.ResourceNotFoundException{Message: aws.String("The specified log stream does not exist.")},
+		getLogEventsErrs: []error{rnf, rnf, nil},
+		getLogEventsOutputs: []*cloudwatchlogs.GetLogEventsOutput{
+			nil, // ignored — error takes precedence
+			nil, // ignored — error takes precedence
+			{
+				Events: []cwltypes.OutputLogEvent{{Message: aws.String("hello from container\n")}},
+			},
+		},
+	}
+	fakeECS := &fakeECSClient{
+		describeTasksOutputs: []*ecs.DescribeTasksOutput{
+			{Tasks: []ecstypes.Task{{LastStatus: aws.String("STOPPED")}}},
+		},
+	}
+	p := NewECSProvider(fakeECS, fakeLogs, &fakeS3Client{}, testHordeConfig())
+	p.pollInterval = time.Millisecond
+
+	reader, err := p.Logs(context.Background(), "arn:aws:ecs:us-east-1:123456789012:task/horde/abc123", true)
+	if err != nil {
+		t.Fatalf("Logs() error = %v, want nil", err)
+	}
+	defer reader.Close()
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v, want nil", err)
+	}
+	if !strings.Contains(string(data), "hello from container") {
+		t.Errorf("output = %q, want it to contain \"hello from container\"", string(data))
+	}
+	if len(fakeLogs.getLogEventsInputs) != 3 {
+		t.Errorf("GetLogEvents called %d times, want 3", len(fakeLogs.getLogEventsInputs))
+	}
+}
+
+func TestECSProvider_Logs_Follow_LogStreamNotCreatedOtherErrorStillFatal(t *testing.T) {
+	t.Parallel()
+	fakeLogs := &fakeCloudWatchLogsClient{
+		getLogEventsErr: fmt.Errorf("ThrottlingException: rate exceeded"),
 	}
 	p := NewECSProvider(&fakeECSClient{}, fakeLogs, &fakeS3Client{}, testHordeConfig())
 	p.pollInterval = time.Millisecond
@@ -795,17 +834,12 @@ func TestECSProvider_Logs_Follow_LogStreamNotCreated(t *testing.T) {
 	}
 	defer reader.Close()
 
-	data, err := io.ReadAll(reader)
+	_, err = io.ReadAll(reader)
 	if err == nil {
 		t.Fatal("ReadAll() error = nil, want non-nil")
 	}
-	_ = data
 	if !strings.Contains(err.Error(), "reading logs") {
 		t.Errorf("error = %q, want it to contain \"reading logs\"", err.Error())
-	}
-	var rnf *cwltypes.ResourceNotFoundException
-	if !errors.As(err, &rnf) {
-		t.Errorf("error type = %T, want *cwltypes.ResourceNotFoundException", err)
 	}
 }
 

--- a/internal/provider/ecs_test.go
+++ b/internal/provider/ecs_test.go
@@ -444,12 +444,107 @@ func TestECSProvider_Status_StoppedNonZeroExit(t *testing.T) {
 	}
 }
 
-func TestECSProvider_Status_UnknownStatus(t *testing.T) {
+func TestECSProvider_Status_Provisioning(t *testing.T) {
 	t.Parallel()
 	fake := &fakeECSClient{
 		describeTasksOutput: &ecs.DescribeTasksOutput{
 			Tasks: []ecstypes.Task{
 				{LastStatus: aws.String("PROVISIONING")},
+			},
+		},
+	}
+	p := NewECSProvider(fake, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	result, err := p.Status(context.Background(), "task-arn")
+	if err != nil {
+		t.Fatalf("Status() error = %v, want nil", err)
+	}
+	if result.State != "pending" {
+		t.Errorf("State = %q, want \"pending\"", result.State)
+	}
+}
+
+func TestECSProvider_Status_Pending(t *testing.T) {
+	t.Parallel()
+	fake := &fakeECSClient{
+		describeTasksOutput: &ecs.DescribeTasksOutput{
+			Tasks: []ecstypes.Task{
+				{LastStatus: aws.String("PENDING")},
+			},
+		},
+	}
+	p := NewECSProvider(fake, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	result, err := p.Status(context.Background(), "task-arn")
+	if err != nil {
+		t.Fatalf("Status() error = %v, want nil", err)
+	}
+	if result.State != "pending" {
+		t.Errorf("State = %q, want \"pending\"", result.State)
+	}
+}
+
+func TestECSProvider_Status_Activating(t *testing.T) {
+	t.Parallel()
+	fake := &fakeECSClient{
+		describeTasksOutput: &ecs.DescribeTasksOutput{
+			Tasks: []ecstypes.Task{
+				{LastStatus: aws.String("ACTIVATING")},
+			},
+		},
+	}
+	p := NewECSProvider(fake, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	result, err := p.Status(context.Background(), "task-arn")
+	if err != nil {
+		t.Fatalf("Status() error = %v, want nil", err)
+	}
+	if result.State != "pending" {
+		t.Errorf("State = %q, want \"pending\"", result.State)
+	}
+}
+
+func TestECSProvider_Status_Deprovisioning(t *testing.T) {
+	t.Parallel()
+	fake := &fakeECSClient{
+		describeTasksOutput: &ecs.DescribeTasksOutput{
+			Tasks: []ecstypes.Task{
+				{LastStatus: aws.String("DEPROVISIONING")},
+			},
+		},
+	}
+	p := NewECSProvider(fake, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	result, err := p.Status(context.Background(), "task-arn")
+	if err != nil {
+		t.Fatalf("Status() error = %v, want nil", err)
+	}
+	if result.State != "stopping" {
+		t.Errorf("State = %q, want \"stopping\"", result.State)
+	}
+}
+
+func TestECSProvider_Status_Stopping(t *testing.T) {
+	t.Parallel()
+	fake := &fakeECSClient{
+		describeTasksOutput: &ecs.DescribeTasksOutput{
+			Tasks: []ecstypes.Task{
+				{LastStatus: aws.String("STOPPING")},
+			},
+		},
+	}
+	p := NewECSProvider(fake, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	result, err := p.Status(context.Background(), "task-arn")
+	if err != nil {
+		t.Fatalf("Status() error = %v, want nil", err)
+	}
+	if result.State != "stopping" {
+		t.Errorf("State = %q, want \"stopping\"", result.State)
+	}
+}
+
+func TestECSProvider_Status_UnrecognizedStatus(t *testing.T) {
+	t.Parallel()
+	fake := &fakeECSClient{
+		describeTasksOutput: &ecs.DescribeTasksOutput{
+			Tasks: []ecstypes.Task{
+				{LastStatus: aws.String("SOME_FUTURE_STATE")},
 			},
 		},
 	}

--- a/internal/provider/ecs_test.go
+++ b/internal/provider/ecs_test.go
@@ -817,8 +817,8 @@ func TestECSProvider_Logs_Follow_LogStreamNotCreated(t *testing.T) {
 	if !strings.Contains(string(data), "hello from container") {
 		t.Errorf("output = %q, want it to contain \"hello from container\"", string(data))
 	}
-	if len(fakeLogs.getLogEventsInputs) != 3 {
-		t.Errorf("GetLogEvents called %d times, want 3", len(fakeLogs.getLogEventsInputs))
+	if len(fakeLogs.getLogEventsInputs) != 4 {
+		t.Errorf("GetLogEvents called %d times, want 4 (3 poll + 1 drain)", len(fakeLogs.getLogEventsInputs))
 	}
 }
 
@@ -848,8 +848,8 @@ func TestECSProvider_Logs_Follow_LogStreamNotCreatedTaskStopped(t *testing.T) {
 	if len(data) != 0 {
 		t.Errorf("output = %q, want empty (no log stream was ever created)", string(data))
 	}
-	if len(fakeLogs.getLogEventsInputs) != 1 {
-		t.Errorf("GetLogEvents called %d times, want 1", len(fakeLogs.getLogEventsInputs))
+	if len(fakeLogs.getLogEventsInputs) != 2 {
+		t.Errorf("GetLogEvents called %d times, want 2 (1 poll + 1 drain)", len(fakeLogs.getLogEventsInputs))
 	}
 	if len(fakeECS.describeTasksInputs) != 1 {
 		t.Errorf("DescribeTasks called %d times, want 1", len(fakeECS.describeTasksInputs))
@@ -961,6 +961,63 @@ func TestECSProvider_Logs_Follow_TaskStops(t *testing.T) {
 	}
 	if *in.LogStreamName != "ecs/horde-worker/abc123" {
 		t.Errorf("LogStreamName = %q, want %q", *in.LogStreamName, "ecs/horde-worker/abc123")
+	}
+}
+
+func TestECSProvider_Logs_Follow_DrainAfterStopped(t *testing.T) {
+	t.Parallel()
+	fakeLogs := &fakeCloudWatchLogsClient{
+		getLogEventsOutputs: []*cloudwatchlogs.GetLogEventsOutput{
+			// Call 0 (main loop): one line, token advances
+			{
+				Events:           []cwltypes.OutputLogEvent{{Message: aws.String("line before stop\n")}},
+				NextForwardToken: aws.String("tok1"),
+			},
+			// Call 1 (main loop): no new data yet, same token
+			{
+				Events:           []cwltypes.OutputLogEvent{},
+				NextForwardToken: aws.String("tok1"),
+			},
+			// Call 2 (drain, 1st): late-arriving line, token advances
+			{
+				Events:           []cwltypes.OutputLogEvent{{Message: aws.String("late line 1\n")}},
+				NextForwardToken: aws.String("tok2"),
+			},
+			// Call 3 (drain, 2nd): another late line, same token → drain exits
+			{
+				Events:           []cwltypes.OutputLogEvent{{Message: aws.String("late line 2\n")}},
+				NextForwardToken: aws.String("tok2"),
+			},
+		},
+	}
+	fakeECS := &fakeECSClient{
+		describeTasksOutputs: []*ecs.DescribeTasksOutput{
+			{Tasks: []ecstypes.Task{{LastStatus: aws.String("RUNNING")}}},
+			{Tasks: []ecstypes.Task{{LastStatus: aws.String("STOPPED")}}},
+		},
+	}
+	p := NewECSProvider(fakeECS, fakeLogs, &fakeS3Client{}, testHordeConfig())
+	p.pollInterval = time.Millisecond
+
+	reader, err := p.Logs(context.Background(), "arn:aws:ecs:us-east-1:123456789012:task/horde/abc123", true)
+	if err != nil {
+		t.Fatalf("Logs() error = %v, want nil", err)
+	}
+	defer reader.Close()
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	want := "line before stop\nlate line 1\nlate line 2\n"
+	if string(data) != want {
+		t.Errorf("Logs output = %q, want %q", string(data), want)
+	}
+	if len(fakeLogs.getLogEventsInputs) != 4 {
+		t.Errorf("GetLogEvents called %d times, want 4 (2 poll + 2 drain)", len(fakeLogs.getLogEventsInputs))
+	}
+	if len(fakeECS.describeTasksInputs) != 2 {
+		t.Errorf("DescribeTasks called %d times, want 2", len(fakeECS.describeTasksInputs))
 	}
 }
 

--- a/internal/provider/ecs_test.go
+++ b/internal/provider/ecs_test.go
@@ -961,6 +961,86 @@ func TestECSProvider_Logs_FollowDescribeTasksError(t *testing.T) {
 	}
 }
 
+func TestECSProvider_Logs_Follow_DescribeTasksFailures(t *testing.T) {
+	t.Parallel()
+	fakeLogs := &fakeCloudWatchLogsClient{
+		getLogEventsOutputs: []*cloudwatchlogs.GetLogEventsOutput{
+			{
+				Events:           []cwltypes.OutputLogEvent{{Message: aws.String("follow line 1\n")}},
+				NextForwardToken: aws.String("tok1"),
+			},
+		},
+	}
+	fakeECS := &fakeECSClient{
+		describeTasksOutputs: []*ecs.DescribeTasksOutput{
+			{Failures: []ecstypes.Failure{{Reason: aws.String("MISSING")}}, Tasks: []ecstypes.Task{}},
+		},
+	}
+	p := NewECSProvider(fakeECS, fakeLogs, &fakeS3Client{}, testHordeConfig())
+	p.pollInterval = time.Millisecond
+
+	reader, err := p.Logs(context.Background(), "arn:aws:ecs:us-east-1:123456789012:task/horde/abc123", true)
+	if err != nil {
+		t.Fatalf("Logs() error = %v, want nil", err)
+	}
+	defer reader.Close()
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v, want nil (pipe must close cleanly)", err)
+	}
+	got := string(data)
+	if !strings.Contains(got, "follow line 1") {
+		t.Errorf("output = %q, want it to contain \"follow line 1\"", got)
+	}
+	if !strings.Contains(got, "task no longer available") {
+		t.Errorf("output = %q, want it to contain \"task no longer available\"", got)
+	}
+	if !strings.Contains(got, "MISSING") {
+		t.Errorf("output = %q, want it to contain \"MISSING\"", got)
+	}
+	if len(fakeECS.describeTasksInputs) != 1 {
+		t.Errorf("DescribeTasks called %d times, want 1", len(fakeECS.describeTasksInputs))
+	}
+}
+
+func TestECSProvider_Logs_Follow_DescribeTasksFailuresNilReason(t *testing.T) {
+	t.Parallel()
+	fakeLogs := &fakeCloudWatchLogsClient{
+		getLogEventsOutputs: []*cloudwatchlogs.GetLogEventsOutput{
+			{
+				Events:           []cwltypes.OutputLogEvent{{Message: aws.String("follow line 1\n")}},
+				NextForwardToken: aws.String("tok1"),
+			},
+		},
+	}
+	fakeECS := &fakeECSClient{
+		describeTasksOutputs: []*ecs.DescribeTasksOutput{
+			{Failures: []ecstypes.Failure{{}}, Tasks: []ecstypes.Task{}},
+		},
+	}
+	p := NewECSProvider(fakeECS, fakeLogs, &fakeS3Client{}, testHordeConfig())
+	p.pollInterval = time.Millisecond
+
+	reader, err := p.Logs(context.Background(), "arn:aws:ecs:us-east-1:123456789012:task/horde/abc123", true)
+	if err != nil {
+		t.Fatalf("Logs() error = %v, want nil", err)
+	}
+	defer reader.Close()
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v, want nil (pipe must close cleanly)", err)
+	}
+	got := string(data)
+	if !strings.Contains(got, "task no longer available") {
+		t.Errorf("output = %q, want it to contain \"task no longer available\"", got)
+	}
+	if len(fakeECS.describeTasksInputs) != 1 {
+		t.Errorf("DescribeTasks called %d times, want 1", len(fakeECS.describeTasksInputs))
+	}
+}
+
 func TestECSProvider_Logs_Follow_EmptyTaskID(t *testing.T) {
 	t.Parallel()
 	p := NewECSProvider(&fakeECSClient{}, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())

--- a/internal/provider/ecs_test.go
+++ b/internal/provider/ecs_test.go
@@ -926,6 +926,41 @@ func TestECSProvider_Logs_Follow_GetLogEventsError(t *testing.T) {
 	}
 }
 
+func TestECSProvider_Logs_FollowDescribeTasksError(t *testing.T) {
+	t.Parallel()
+	fakeLogs := &fakeCloudWatchLogsClient{
+		// No outputs configured — GetLogEvents returns empty output on every call,
+		// keeping the goroutine looping without producing log events.
+	}
+	fakeECS := &fakeECSClient{
+		describeTasksErr: fmt.Errorf("ExpiredTokenException: security token has expired"),
+	}
+	p := NewECSProvider(fakeECS, fakeLogs, &fakeS3Client{}, testHordeConfig())
+	p.pollInterval = time.Millisecond
+
+	reader, err := p.Logs(context.Background(), "arn:aws:ecs:us-east-1:123456789012:task/horde/abc123", true)
+	if err != nil {
+		t.Fatalf("Logs() error = %v, want nil", err)
+	}
+	defer reader.Close()
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v, want nil (goroutine should close pipe normally)", err)
+	}
+	got := string(data)
+	if !strings.Contains(got, "unable to determine task completion") {
+		t.Errorf("output = %q, want it to contain \"unable to determine task completion\"", got)
+	}
+	if !strings.Contains(got, "stopping follow") {
+		t.Errorf("output = %q, want it to contain \"stopping follow\"", got)
+	}
+	// Verify DescribeTasks was called exactly maxConsecutiveDescribeFailures times (5).
+	if len(fakeECS.describeTasksInputs) != 5 {
+		t.Errorf("DescribeTasks called %d times, want %d", len(fakeECS.describeTasksInputs), 5)
+	}
+}
+
 func TestECSProvider_Logs_Follow_EmptyTaskID(t *testing.T) {
 	t.Parallel()
 	p := NewECSProvider(&fakeECSClient{}, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())

--- a/internal/provider/ecs_test.go
+++ b/internal/provider/ecs_test.go
@@ -65,7 +65,7 @@ func TestECSProvider_InterfaceCompliance(t *testing.T) {
 	}
 }
 
-func TestECSProvider_Launch_Stub(t *testing.T) {
+func TestECSProvider_Launch_NilResponse(t *testing.T) {
 	t.Parallel()
 	p := NewECSProvider(&fakeECSClient{}, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
 	result, err := p.Launch(context.Background(), LaunchOpts{})
@@ -75,8 +75,8 @@ func TestECSProvider_Launch_Stub(t *testing.T) {
 	if err == nil {
 		t.Fatal("Launch() error = nil, want non-nil")
 	}
-	if !strings.Contains(err.Error(), "not implemented") {
-		t.Errorf("Launch() error = %q, want it to contain \"not implemented\"", err.Error())
+	if !strings.Contains(err.Error(), "launching ECS task") {
+		t.Errorf("Launch() error = %q, want it to contain \"launching ECS task\"", err.Error())
 	}
 }
 

--- a/internal/provider/ecs_test.go
+++ b/internal/provider/ecs_test.go
@@ -1105,6 +1105,154 @@ func TestECSProvider_Logs_Follow_GetLogEventsError(t *testing.T) {
 	}
 }
 
+func TestECSProvider_Logs_Follow_DrainTransientErrorRetrySucceeds(t *testing.T) {
+	t.Parallel()
+	fakeLogs := &fakeCloudWatchLogsClient{
+		getLogEventsOutputs: []*cloudwatchlogs.GetLogEventsOutput{
+			// Call 0 (poll): line delivered, token advances
+			{
+				Events:           []cwltypes.OutputLogEvent{{Message: aws.String("line before stop\n")}},
+				NextForwardToken: aws.String("tok1"),
+			},
+			// Call 1 (drain, first attempt): output ignored — error takes precedence
+			{},
+			// Call 2 (drain, retry): late line delivered, token advances
+			{
+				Events:           []cwltypes.OutputLogEvent{{Message: aws.String("late line\n")}},
+				NextForwardToken: aws.String("tok2"),
+			},
+			// Call 3 (drain, next iteration): empty + same token → drain exits
+			{
+				Events:           []cwltypes.OutputLogEvent{},
+				NextForwardToken: aws.String("tok2"),
+			},
+		},
+		getLogEventsErrs: []error{nil, fmt.Errorf("ThrottlingException: rate exceeded")},
+	}
+	fakeECS := &fakeECSClient{
+		describeTasksOutputs: []*ecs.DescribeTasksOutput{
+			{Tasks: []ecstypes.Task{{LastStatus: aws.String("STOPPED")}}},
+		},
+	}
+	p := NewECSProvider(fakeECS, fakeLogs, &fakeS3Client{}, testHordeConfig())
+	p.pollInterval = time.Millisecond
+
+	reader, err := p.Logs(context.Background(), "arn:aws:ecs:us-east-1:123456789012:task/horde/abc123", true)
+	if err != nil {
+		t.Fatalf("Logs() error = %v, want nil", err)
+	}
+	defer reader.Close()
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v, want nil", err)
+	}
+	if !strings.Contains(string(data), "line before stop") {
+		t.Errorf("data = %q, want it to contain \"line before stop\"", string(data))
+	}
+	if !strings.Contains(string(data), "late line") {
+		t.Errorf("data = %q, want it to contain \"late line\"", string(data))
+	}
+	if strings.Contains(string(data), "WARNING") {
+		t.Errorf("data = %q, want no WARNING", string(data))
+	}
+	if len(fakeLogs.getLogEventsInputs) != 4 {
+		t.Errorf("GetLogEvents called %d times, want 4 (1 poll + 1 failed drain + 1 retry + 1 drain-exit)", len(fakeLogs.getLogEventsInputs))
+	}
+}
+
+func TestECSProvider_Logs_Follow_DrainTransientErrorRetryFails(t *testing.T) {
+	t.Parallel()
+	fakeLogs := &fakeCloudWatchLogsClient{
+		getLogEventsOutputs: []*cloudwatchlogs.GetLogEventsOutput{
+			// Call 0 (poll): line delivered, token advances
+			{
+				Events:           []cwltypes.OutputLogEvent{{Message: aws.String("line before stop\n")}},
+				NextForwardToken: aws.String("tok1"),
+			},
+		},
+		getLogEventsErrs: []error{
+			nil,
+			fmt.Errorf("ThrottlingException: rate exceeded"),
+			fmt.Errorf("ThrottlingException: rate exceeded"),
+		},
+	}
+	fakeECS := &fakeECSClient{
+		describeTasksOutputs: []*ecs.DescribeTasksOutput{
+			{Tasks: []ecstypes.Task{{LastStatus: aws.String("STOPPED")}}},
+		},
+	}
+	p := NewECSProvider(fakeECS, fakeLogs, &fakeS3Client{}, testHordeConfig())
+	p.pollInterval = time.Millisecond
+
+	reader, err := p.Logs(context.Background(), "arn:aws:ecs:us-east-1:123456789012:task/horde/abc123", true)
+	if err != nil {
+		t.Fatalf("Logs() error = %v, want nil", err)
+	}
+	defer reader.Close()
+
+	data, err := io.ReadAll(reader)
+	if err == nil {
+		t.Fatal("ReadAll() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "reading logs") {
+		t.Errorf("error = %q, want it to contain \"reading logs\"", err.Error())
+	}
+	if !strings.Contains(string(data), "line before stop") {
+		t.Errorf("data = %q, want it to contain \"line before stop\"", string(data))
+	}
+	if !strings.Contains(string(data), "WARNING: output may be incomplete") {
+		t.Errorf("data = %q, want it to contain \"WARNING: output may be incomplete\"", string(data))
+	}
+	if len(fakeLogs.getLogEventsInputs) != 3 {
+		t.Errorf("GetLogEvents called %d times, want 3 (1 poll + 1 failed drain + 1 failed retry)", len(fakeLogs.getLogEventsInputs))
+	}
+}
+
+func TestECSProvider_Logs_Follow_DrainRNFBreaksCleanly(t *testing.T) {
+	t.Parallel()
+	fakeLogs := &fakeCloudWatchLogsClient{
+		getLogEventsOutputs: []*cloudwatchlogs.GetLogEventsOutput{
+			// Call 0 (poll): line delivered, token advances
+			{
+				Events:           []cwltypes.OutputLogEvent{{Message: aws.String("line before stop\n")}},
+				NextForwardToken: aws.String("tok1"),
+			},
+		},
+		getLogEventsErrs: []error{
+			nil,
+			&cwltypes.ResourceNotFoundException{Message: aws.String("log stream not found")},
+		},
+	}
+	fakeECS := &fakeECSClient{
+		describeTasksOutputs: []*ecs.DescribeTasksOutput{
+			{Tasks: []ecstypes.Task{{LastStatus: aws.String("STOPPED")}}},
+		},
+	}
+	p := NewECSProvider(fakeECS, fakeLogs, &fakeS3Client{}, testHordeConfig())
+	p.pollInterval = time.Millisecond
+
+	reader, err := p.Logs(context.Background(), "arn:aws:ecs:us-east-1:123456789012:task/horde/abc123", true)
+	if err != nil {
+		t.Fatalf("Logs() error = %v, want nil", err)
+	}
+	defer reader.Close()
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v, want nil", err)
+	}
+	if !strings.Contains(string(data), "line before stop") {
+		t.Errorf("data = %q, want it to contain \"line before stop\"", string(data))
+	}
+	if strings.Contains(string(data), "WARNING") {
+		t.Errorf("data = %q, want no WARNING", string(data))
+	}
+	if len(fakeLogs.getLogEventsInputs) != 2 {
+		t.Errorf("GetLogEvents called %d times, want 2 (1 poll + 1 drain with RNF)", len(fakeLogs.getLogEventsInputs))
+	}
+}
+
 func TestECSProvider_Logs_Follow_NilResponse(t *testing.T) {
 	t.Parallel()
 	fakeLogs := &fakeCloudWatchLogsClient{

--- a/internal/provider/ecs_test.go
+++ b/internal/provider/ecs_test.go
@@ -744,6 +744,24 @@ func TestECSProvider_Logs_APIError(t *testing.T) {
 	}
 }
 
+func TestECSProvider_Logs_NilResponse(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCloudWatchLogsClient{
+		getLogEventsOutputs: []*cloudwatchlogs.GetLogEventsOutput{nil},
+	}
+	p := NewECSProvider(&fakeECSClient{}, fake, &fakeS3Client{}, testHordeConfig())
+	_, err := p.Logs(context.Background(), "arn:aws:ecs:us-east-1:123:task/c/task1", false)
+	if err == nil {
+		t.Fatal("Logs() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "reading logs") {
+		t.Errorf("error = %q, want it to contain \"reading logs\"", err.Error())
+	}
+	if !strings.Contains(err.Error(), "nil response") {
+		t.Errorf("error = %q, want it to contain \"nil response\"", err.Error())
+	}
+}
+
 func TestECSProvider_Logs_LogStreamNotCreated(t *testing.T) {
 	t.Parallel()
 	fake := &fakeCloudWatchLogsClient{
@@ -923,6 +941,32 @@ func TestECSProvider_Logs_Follow_GetLogEventsError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "reading logs") {
 		t.Errorf("error = %q, want it to contain \"reading logs\"", err.Error())
+	}
+}
+
+func TestECSProvider_Logs_Follow_NilResponse(t *testing.T) {
+	t.Parallel()
+	fakeLogs := &fakeCloudWatchLogsClient{
+		getLogEventsOutputs: []*cloudwatchlogs.GetLogEventsOutput{nil},
+	}
+	p := NewECSProvider(&fakeECSClient{}, fakeLogs, &fakeS3Client{}, testHordeConfig())
+	p.pollInterval = time.Millisecond
+
+	reader, err := p.Logs(context.Background(), "arn:aws:ecs:us-east-1:123456789012:task/horde/abc123", true)
+	if err != nil {
+		t.Fatalf("Logs() error = %v, want nil", err)
+	}
+	defer reader.Close()
+
+	_, err = io.ReadAll(reader)
+	if err == nil {
+		t.Fatal("ReadAll() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "reading logs") {
+		t.Errorf("error = %q, want it to contain \"reading logs\"", err.Error())
+	}
+	if !strings.Contains(err.Error(), "nil response") {
+		t.Errorf("error = %q, want it to contain \"nil response\"", err.Error())
 	}
 }
 

--- a/internal/provider/ecs_test.go
+++ b/internal/provider/ecs_test.go
@@ -740,6 +740,53 @@ func TestECSProvider_Logs_APIError(t *testing.T) {
 	}
 }
 
+func TestECSProvider_Logs_LogStreamNotCreated(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCloudWatchLogsClient{
+		getLogEventsErr: &cwltypes.ResourceNotFoundException{Message: aws.String("The specified log stream does not exist.")},
+	}
+	p := NewECSProvider(&fakeECSClient{}, fake, &fakeS3Client{}, testHordeConfig())
+	_, err := p.Logs(context.Background(), "arn:aws:ecs:us-east-1:123:task/c/task1", false)
+	if err == nil {
+		t.Fatal("Logs() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "reading logs") {
+		t.Errorf("error = %q, want it to contain \"reading logs\"", err.Error())
+	}
+	var rnf *cwltypes.ResourceNotFoundException
+	if !errors.As(err, &rnf) {
+		t.Errorf("error type = %T, want *cwltypes.ResourceNotFoundException", err)
+	}
+}
+
+func TestECSProvider_Logs_Follow_LogStreamNotCreated(t *testing.T) {
+	t.Parallel()
+	fakeLogs := &fakeCloudWatchLogsClient{
+		getLogEventsErr: &cwltypes.ResourceNotFoundException{Message: aws.String("The specified log stream does not exist.")},
+	}
+	p := NewECSProvider(&fakeECSClient{}, fakeLogs, &fakeS3Client{}, testHordeConfig())
+	p.pollInterval = time.Millisecond
+
+	reader, err := p.Logs(context.Background(), "arn:aws:ecs:us-east-1:123456789012:task/horde/abc123", true)
+	if err != nil {
+		t.Fatalf("Logs() error = %v, want nil", err)
+	}
+	defer reader.Close()
+
+	data, err := io.ReadAll(reader)
+	if err == nil {
+		t.Fatal("ReadAll() error = nil, want non-nil")
+	}
+	_ = data
+	if !strings.Contains(err.Error(), "reading logs") {
+		t.Errorf("error = %q, want it to contain \"reading logs\"", err.Error())
+	}
+	var rnf *cwltypes.ResourceNotFoundException
+	if !errors.As(err, &rnf) {
+		t.Errorf("error type = %T, want *cwltypes.ResourceNotFoundException", err)
+	}
+}
+
 func TestECSProvider_Logs_Follow_TaskStops(t *testing.T) {
 	t.Parallel()
 	fakeLogs := &fakeCloudWatchLogsClient{

--- a/internal/provider/ecs_test.go
+++ b/internal/provider/ecs_test.go
@@ -3,12 +3,14 @@ package provider
 import (
 	"context"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	cloudwatchlogs "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	cwltypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -43,10 +45,22 @@ func (f *fakeECSClient) StopTask(ctx context.Context, params *ecs.StopTaskInput,
 	return nil, nil
 }
 
-type fakeCloudWatchLogsClient struct{}
+type fakeCloudWatchLogsClient struct {
+	getLogEventsInputs  []*cloudwatchlogs.GetLogEventsInput
+	getLogEventsOutputs []*cloudwatchlogs.GetLogEventsOutput
+	getLogEventsErr     error
+}
 
 func (f *fakeCloudWatchLogsClient) GetLogEvents(ctx context.Context, params *cloudwatchlogs.GetLogEventsInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.GetLogEventsOutput, error) {
-	return nil, nil
+	f.getLogEventsInputs = append(f.getLogEventsInputs, params)
+	if f.getLogEventsErr != nil {
+		return nil, f.getLogEventsErr
+	}
+	idx := len(f.getLogEventsInputs) - 1
+	if idx < len(f.getLogEventsOutputs) {
+		return f.getLogEventsOutputs[idx], nil
+	}
+	return &cloudwatchlogs.GetLogEventsOutput{}, nil
 }
 
 type fakeS3Client struct{}
@@ -62,6 +76,7 @@ func testHordeConfig() *config.HordeConfig {
 		Subnets:               []string{"subnet-abc"},
 		SecurityGroup:         "sg-123",
 		LogGroup:              "/ecs/horde-worker",
+		LogStreamPrefix:       "ecs",
 		ArtifactsBucket:       "my-horde-artifacts",
 		RunsTable:             "horde-runs",
 		MaxConcurrent:         5,
@@ -529,18 +544,216 @@ func TestECSProvider_Status_NilResponse(t *testing.T) {
 	}
 }
 
-func TestECSProvider_Logs_Stub(t *testing.T) {
+func TestECSProvider_Logs_Success(t *testing.T) {
+	t.Parallel()
+	token := "token-1"
+	fake := &fakeCloudWatchLogsClient{
+		getLogEventsOutputs: []*cloudwatchlogs.GetLogEventsOutput{
+			{
+				Events: []cwltypes.OutputLogEvent{
+					{Message: aws.String("line 1\n")},
+					{Message: aws.String("line 2\n")},
+				},
+				NextForwardToken: aws.String(token),
+			},
+			{
+				// Second call returns same token — signals end of pagination
+				Events:           []cwltypes.OutputLogEvent{},
+				NextForwardToken: aws.String(token),
+			},
+		},
+	}
+	p := NewECSProvider(&fakeECSClient{}, fake, &fakeS3Client{}, testHordeConfig())
+	reader, err := p.Logs(context.Background(), "arn:aws:ecs:us-east-1:123456789012:task/horde/abc123", false)
+	if err != nil {
+		t.Fatalf("Logs() error = %v, want nil", err)
+	}
+	defer reader.Close()
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	want := "line 1\nline 2\n"
+	if string(data) != want {
+		t.Errorf("Logs output = %q, want %q", string(data), want)
+	}
+	// Verify GetLogEventsInput on first call
+	if len(fake.getLogEventsInputs) < 1 {
+		t.Fatal("GetLogEvents was not called")
+	}
+	in := fake.getLogEventsInputs[0]
+	if *in.LogGroupName != "/ecs/horde-worker" {
+		t.Errorf("LogGroupName = %q, want %q", *in.LogGroupName, "/ecs/horde-worker")
+	}
+	if *in.LogStreamName != "ecs/horde-worker/abc123" {
+		t.Errorf("LogStreamName = %q, want %q", *in.LogStreamName, "ecs/horde-worker/abc123")
+	}
+	if !*in.StartFromHead {
+		t.Error("StartFromHead = false, want true")
+	}
+	if in.NextToken != nil {
+		t.Errorf("first call NextToken = %v, want nil", in.NextToken)
+	}
+}
+
+func TestECSProvider_Logs_Pagination(t *testing.T) {
+	t.Parallel()
+	token1 := "token-1"
+	token2 := "token-2"
+	fake := &fakeCloudWatchLogsClient{
+		getLogEventsOutputs: []*cloudwatchlogs.GetLogEventsOutput{
+			{
+				Events: []cwltypes.OutputLogEvent{
+					{Message: aws.String("page 1\n")},
+				},
+				NextForwardToken: aws.String(token1),
+			},
+			{
+				Events: []cwltypes.OutputLogEvent{
+					{Message: aws.String("page 2\n")},
+				},
+				NextForwardToken: aws.String(token2),
+			},
+			{
+				Events:           []cwltypes.OutputLogEvent{},
+				NextForwardToken: aws.String(token2), // same as sent — done
+			},
+		},
+	}
+	p := NewECSProvider(&fakeECSClient{}, fake, &fakeS3Client{}, testHordeConfig())
+	reader, err := p.Logs(context.Background(), "arn:aws:ecs:us-east-1:123:task/c/task1", false)
+	if err != nil {
+		t.Fatalf("Logs() error = %v, want nil", err)
+	}
+	defer reader.Close()
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	want := "page 1\npage 2\n"
+	if string(data) != want {
+		t.Errorf("Logs output = %q, want %q", string(data), want)
+	}
+	// Verify second call forwarded the token
+	if len(fake.getLogEventsInputs) < 2 {
+		t.Fatalf("GetLogEvents called %d times, want >= 2", len(fake.getLogEventsInputs))
+	}
+	if fake.getLogEventsInputs[1].NextToken == nil || *fake.getLogEventsInputs[1].NextToken != token1 {
+		t.Errorf("second call NextToken = %v, want %q", fake.getLogEventsInputs[1].NextToken, token1)
+	}
+}
+
+func TestECSProvider_Logs_Empty(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCloudWatchLogsClient{
+		getLogEventsOutputs: []*cloudwatchlogs.GetLogEventsOutput{
+			{Events: []cwltypes.OutputLogEvent{}},
+		},
+	}
+	p := NewECSProvider(&fakeECSClient{}, fake, &fakeS3Client{}, testHordeConfig())
+	reader, err := p.Logs(context.Background(), "arn:aws:ecs:us-east-1:123:task/c/task1", false)
+	if err != nil {
+		t.Fatalf("Logs() error = %v, want nil", err)
+	}
+	defer reader.Close()
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if len(data) != 0 {
+		t.Errorf("Logs output = %q, want empty", string(data))
+	}
+}
+
+func TestECSProvider_Logs_APIError(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCloudWatchLogsClient{
+		getLogEventsErr: fmt.Errorf("ResourceNotFoundException: log group does not exist"),
+	}
+	p := NewECSProvider(&fakeECSClient{}, fake, &fakeS3Client{}, testHordeConfig())
+	_, err := p.Logs(context.Background(), "arn:aws:ecs:us-east-1:123:task/c/task1", false)
+	if err == nil {
+		t.Fatal("Logs() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "reading logs") {
+		t.Errorf("error = %q, want it to contain \"reading logs\"", err.Error())
+	}
+}
+
+func TestECSProvider_Logs_FollowNotImplemented(t *testing.T) {
 	t.Parallel()
 	p := NewECSProvider(&fakeECSClient{}, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
-	result, err := p.Logs(context.Background(), "", false)
+	result, err := p.Logs(context.Background(), "task-arn", true)
 	if result != nil {
 		t.Errorf("Logs() result = %v, want nil", result)
 	}
 	if err == nil {
 		t.Fatal("Logs() error = nil, want non-nil")
 	}
-	if !strings.Contains(err.Error(), "not implemented") {
-		t.Errorf("Logs() error = %q, want it to contain \"not implemented\"", err.Error())
+	if !strings.Contains(err.Error(), "follow mode not implemented") {
+		t.Errorf("error = %q, want it to contain \"follow mode not implemented\"", err.Error())
+	}
+}
+
+func TestECSProvider_Logs_BareTaskID(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCloudWatchLogsClient{
+		getLogEventsOutputs: []*cloudwatchlogs.GetLogEventsOutput{
+			{Events: []cwltypes.OutputLogEvent{}},
+		},
+	}
+	p := NewECSProvider(&fakeECSClient{}, fake, &fakeS3Client{}, testHordeConfig())
+	_, err := p.Logs(context.Background(), "abc123", false)
+	if err != nil {
+		t.Fatalf("Logs() error = %v, want nil", err)
+	}
+	if len(fake.getLogEventsInputs) < 1 {
+		t.Fatal("GetLogEvents was not called")
+	}
+	// bare ID is used directly as task ID
+	if *fake.getLogEventsInputs[0].LogStreamName != "ecs/horde-worker/abc123" {
+		t.Errorf("LogStreamName = %q, want %q", *fake.getLogEventsInputs[0].LogStreamName, "ecs/horde-worker/abc123")
+	}
+}
+
+func TestECSProvider_Logs_EmptyTaskID(t *testing.T) {
+	t.Parallel()
+	p := NewECSProvider(&fakeECSClient{}, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	_, err := p.Logs(context.Background(), "arn:aws:ecs:us-east-1:123:task/horde/", false)
+	if err == nil {
+		t.Fatal("Logs() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "empty task ID") {
+		t.Errorf("error = %q, want it to contain \"empty task ID\"", err.Error())
+	}
+}
+
+func TestECSProvider_Logs_NewlineHandling(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCloudWatchLogsClient{
+		getLogEventsOutputs: []*cloudwatchlogs.GetLogEventsOutput{
+			{
+				Events: []cwltypes.OutputLogEvent{
+					{Message: aws.String("no newline")},
+					{Message: aws.String("has newline\n")},
+				},
+			},
+		},
+	}
+	p := NewECSProvider(&fakeECSClient{}, fake, &fakeS3Client{}, testHordeConfig())
+	reader, err := p.Logs(context.Background(), "arn:aws:ecs:us-east-1:123:task/c/t1", false)
+	if err != nil {
+		t.Fatalf("Logs() error = %v, want nil", err)
+	}
+	defer reader.Close()
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	// Messages without trailing newlines get one added
+	want := "no newline\nhas newline\n"
+	if string(data) != want {
+		t.Errorf("Logs output = %q, want %q", string(data), want)
 	}
 }
 

--- a/internal/provider/ecs_test.go
+++ b/internal/provider/ecs_test.go
@@ -585,6 +585,25 @@ func TestECSProvider_Status_NilResponse(t *testing.T) {
 	}
 }
 
+func TestECSProvider_Status_DescribeTasksTypedError(t *testing.T) {
+	t.Parallel()
+	fake := &fakeECSClient{
+		describeTasksErr: &ecstypes.ClusterNotFoundException{Message: aws.String("cluster not found")},
+	}
+	p := NewECSProvider(fake, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	_, err := p.Status(context.Background(), "arn:aws:ecs:us-east-1:123456789012:task/horde/nonexistent")
+	if err == nil {
+		t.Fatal("Status() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "describing ECS task") {
+		t.Errorf("error = %q, want it to contain \"describing ECS task\"", err.Error())
+	}
+	var cnf *ecstypes.ClusterNotFoundException
+	if !errors.As(err, &cnf) {
+		t.Errorf("error type = %T, want *ecstypes.ClusterNotFoundException", err)
+	}
+}
+
 func TestECSProvider_Logs_Success(t *testing.T) {
 	t.Parallel()
 	token := "token-1"
@@ -1049,6 +1068,27 @@ func TestECSProvider_Stop_IgnoresResultsDir(t *testing.T) {
 	}
 	if *fake.stopTaskInput.Task != "arn:aws:ecs:us-east-1:123456789012:task/horde/abc123" {
 		t.Errorf("Task = %q", *fake.stopTaskInput.Task)
+	}
+}
+
+func TestECSProvider_Stop_AlreadyStopped(t *testing.T) {
+	t.Parallel()
+	fake := &fakeECSClient{
+		stopTaskErr: &ecstypes.InvalidParameterException{Message: aws.String("The referenced task was already stopped.")},
+	}
+	p := NewECSProvider(fake, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	err := p.Stop(context.Background(), StopOpts{
+		InstanceID: "arn:aws:ecs:us-east-1:123456789012:task/horde/abc123",
+	})
+	if err == nil {
+		t.Fatal("Stop() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "stopping ECS task") {
+		t.Errorf("error = %q, want it to contain \"stopping ECS task\"", err.Error())
+	}
+	var ipe *ecstypes.InvalidParameterException
+	if !errors.As(err, &ipe) {
+		t.Errorf("error type = %T, want *ecstypes.InvalidParameterException", err)
 	}
 }
 

--- a/internal/provider/ecs_test.go
+++ b/internal/provider/ecs_test.go
@@ -1367,3 +1367,46 @@ func TestECSProvider_ReadFile_EmptyRunID(t *testing.T) {
 		t.Errorf("ReadFile() error = %q, want it to contain \"run ID is required\"", err.Error())
 	}
 }
+
+func TestECSProvider_ReadFile_NilResponse(t *testing.T) {
+	t.Parallel()
+	// fakeS3Client with zero fields returns (nil, nil) from GetObject — triggers nil-response guard.
+	fake := &fakeS3Client{}
+	p := NewECSProvider(&fakeECSClient{}, &fakeCloudWatchLogsClient{}, fake, testHordeConfig())
+	_, err := p.ReadFile(context.Background(), ReadFileOpts{
+		RunID:    "run-001",
+		Path:     ".orc/audit/foo.json",
+		Metadata: map[string]string{"artifacts_bucket": "my-horde-artifacts"},
+	})
+	if err == nil {
+		t.Fatal("ReadFile() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "reading file from s3") {
+		t.Errorf("error = %q, want it to contain \"reading file from s3\"", err.Error())
+	}
+	if !strings.Contains(err.Error(), "nil response") {
+		t.Errorf("error = %q, want it to contain \"nil response\"", err.Error())
+	}
+}
+
+func TestECSProvider_ReadFile_NilBody(t *testing.T) {
+	t.Parallel()
+	fake := &fakeS3Client{
+		getObjectOutput: &s3.GetObjectOutput{Body: nil},
+	}
+	p := NewECSProvider(&fakeECSClient{}, &fakeCloudWatchLogsClient{}, fake, testHordeConfig())
+	_, err := p.ReadFile(context.Background(), ReadFileOpts{
+		RunID:    "run-001",
+		Path:     ".orc/audit/foo.json",
+		Metadata: map[string]string{"artifacts_bucket": "my-horde-artifacts"},
+	})
+	if err == nil {
+		t.Fatal("ReadFile() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "reading file from s3") {
+		t.Errorf("error = %q, want it to contain \"reading file from s3\"", err.Error())
+	}
+	if !strings.Contains(err.Error(), "nil response") {
+		t.Errorf("error = %q, want it to contain \"nil response\"", err.Error())
+	}
+}

--- a/internal/provider/ecs_test.go
+++ b/internal/provider/ecs_test.go
@@ -27,6 +27,10 @@ type fakeECSClient struct {
 	describeTasksErr     error
 	describeTasksInputs  []*ecs.DescribeTasksInput
 	describeTasksOutputs []*ecs.DescribeTasksOutput
+
+	stopTaskInput  *ecs.StopTaskInput
+	stopTaskOutput *ecs.StopTaskOutput
+	stopTaskErr    error
 }
 
 func (f *fakeECSClient) RunTask(ctx context.Context, params *ecs.RunTaskInput, optFns ...func(*ecs.Options)) (*ecs.RunTaskOutput, error) {
@@ -55,7 +59,14 @@ func (f *fakeECSClient) DescribeTasks(ctx context.Context, params *ecs.DescribeT
 	return f.describeTasksOutput, nil
 }
 func (f *fakeECSClient) StopTask(ctx context.Context, params *ecs.StopTaskInput, optFns ...func(*ecs.Options)) (*ecs.StopTaskOutput, error) {
-	return nil, nil
+	f.stopTaskInput = params
+	if f.stopTaskErr != nil {
+		return nil, f.stopTaskErr
+	}
+	if f.stopTaskOutput != nil {
+		return f.stopTaskOutput, nil
+	}
+	return &ecs.StopTaskOutput{}, nil
 }
 
 type fakeCloudWatchLogsClient struct {
@@ -967,15 +978,64 @@ func TestECSProvider_Logs_NewlineHandling(t *testing.T) {
 	}
 }
 
-func TestECSProvider_Stop_Stub(t *testing.T) {
+func TestECSProvider_Stop_Success(t *testing.T) {
 	t.Parallel()
-	p := NewECSProvider(&fakeECSClient{}, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
-	err := p.Stop(context.Background(), StopOpts{})
+	fake := &fakeECSClient{}
+	p := NewECSProvider(fake, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	instanceID := "arn:aws:ecs:us-east-1:123456789012:task/horde/abc123"
+	err := p.Stop(context.Background(), StopOpts{
+		InstanceID: instanceID,
+	})
+	if err != nil {
+		t.Fatalf("Stop() error = %v, want nil", err)
+	}
+	if fake.stopTaskInput == nil {
+		t.Fatal("StopTask was not called")
+	}
+	if *fake.stopTaskInput.Cluster != testHordeConfig().ClusterARN {
+		t.Errorf("Cluster = %q, want %q", *fake.stopTaskInput.Cluster, testHordeConfig().ClusterARN)
+	}
+	if *fake.stopTaskInput.Task != instanceID {
+		t.Errorf("Task = %q, want %q", *fake.stopTaskInput.Task, instanceID)
+	}
+	if *fake.stopTaskInput.Reason != "horde kill" {
+		t.Errorf("Reason = %q, want %q", *fake.stopTaskInput.Reason, "horde kill")
+	}
+}
+
+func TestECSProvider_Stop_Error(t *testing.T) {
+	t.Parallel()
+	fake := &fakeECSClient{
+		stopTaskErr: fmt.Errorf("AccessDeniedException: not authorized"),
+	}
+	p := NewECSProvider(fake, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	err := p.Stop(context.Background(), StopOpts{
+		InstanceID: "arn:aws:ecs:us-east-1:123456789012:task/horde/abc123",
+	})
 	if err == nil {
 		t.Fatal("Stop() error = nil, want non-nil")
 	}
-	if !strings.Contains(err.Error(), "not implemented") {
-		t.Errorf("Stop() error = %q, want it to contain \"not implemented\"", err.Error())
+	if !strings.Contains(err.Error(), "stopping ECS task") {
+		t.Errorf("error = %q, want it to contain \"stopping ECS task\"", err.Error())
+	}
+}
+
+func TestECSProvider_Stop_IgnoresResultsDir(t *testing.T) {
+	t.Parallel()
+	fake := &fakeECSClient{}
+	p := NewECSProvider(fake, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	err := p.Stop(context.Background(), StopOpts{
+		InstanceID: "arn:aws:ecs:us-east-1:123456789012:task/horde/abc123",
+		ResultsDir: "/some/path/that/should/be/ignored",
+	})
+	if err != nil {
+		t.Fatalf("Stop() error = %v, want nil", err)
+	}
+	if fake.stopTaskInput == nil {
+		t.Fatal("StopTask was not called")
+	}
+	if *fake.stopTaskInput.Task != "arn:aws:ecs:us-east-1:123456789012:task/horde/abc123" {
+		t.Errorf("Task = %q", *fake.stopTaskInput.Task)
 	}
 }
 

--- a/internal/provider/ecs_test.go
+++ b/internal/provider/ecs_test.go
@@ -1,0 +1,138 @@
+package provider
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	cloudwatchlogs "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/jorge-barreto/horde/internal/config"
+)
+
+type fakeECSClient struct{}
+
+func (f *fakeECSClient) RunTask(ctx context.Context, params *ecs.RunTaskInput, optFns ...func(*ecs.Options)) (*ecs.RunTaskOutput, error) {
+	return nil, nil
+}
+func (f *fakeECSClient) DescribeTasks(ctx context.Context, params *ecs.DescribeTasksInput, optFns ...func(*ecs.Options)) (*ecs.DescribeTasksOutput, error) {
+	return nil, nil
+}
+func (f *fakeECSClient) StopTask(ctx context.Context, params *ecs.StopTaskInput, optFns ...func(*ecs.Options)) (*ecs.StopTaskOutput, error) {
+	return nil, nil
+}
+
+type fakeCloudWatchLogsClient struct{}
+
+func (f *fakeCloudWatchLogsClient) GetLogEvents(ctx context.Context, params *cloudwatchlogs.GetLogEventsInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.GetLogEventsOutput, error) {
+	return nil, nil
+}
+
+type fakeS3Client struct{}
+
+func (f *fakeS3Client) GetObject(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	return nil, nil
+}
+
+func testHordeConfig() *config.HordeConfig {
+	return &config.HordeConfig{
+		ClusterARN:            "arn:aws:ecs:us-east-1:123456789012:cluster/horde",
+		TaskDefinitionARN:     "arn:aws:ecs:us-east-1:123456789012:task-definition/horde-worker:1",
+		Subnets:               []string{"subnet-abc"},
+		SecurityGroup:         "sg-123",
+		LogGroup:              "/ecs/horde-worker",
+		ArtifactsBucket:       "my-horde-artifacts",
+		RunsTable:             "horde-runs",
+		MaxConcurrent:         5,
+		DefaultTimeoutMinutes: 1440,
+	}
+}
+
+func TestNewECSProvider(t *testing.T) {
+	t.Parallel()
+	p := NewECSProvider(&fakeECSClient{}, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	if p == nil {
+		t.Error("NewECSProvider() returned nil")
+	}
+}
+
+func TestECSProvider_InterfaceCompliance(t *testing.T) {
+	t.Parallel()
+	var p Provider = NewECSProvider(&fakeECSClient{}, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	if p == nil {
+		t.Error("NewECSProvider() returned nil")
+	}
+}
+
+func TestECSProvider_Launch_Stub(t *testing.T) {
+	t.Parallel()
+	p := NewECSProvider(&fakeECSClient{}, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	result, err := p.Launch(context.Background(), LaunchOpts{})
+	if result != nil {
+		t.Errorf("Launch() result = %v, want nil", result)
+	}
+	if err == nil {
+		t.Fatal("Launch() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "not implemented") {
+		t.Errorf("Launch() error = %q, want it to contain \"not implemented\"", err.Error())
+	}
+}
+
+func TestECSProvider_Status_Stub(t *testing.T) {
+	t.Parallel()
+	p := NewECSProvider(&fakeECSClient{}, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	result, err := p.Status(context.Background(), "")
+	if result != nil {
+		t.Errorf("Status() result = %v, want nil", result)
+	}
+	if err == nil {
+		t.Fatal("Status() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "not implemented") {
+		t.Errorf("Status() error = %q, want it to contain \"not implemented\"", err.Error())
+	}
+}
+
+func TestECSProvider_Logs_Stub(t *testing.T) {
+	t.Parallel()
+	p := NewECSProvider(&fakeECSClient{}, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	result, err := p.Logs(context.Background(), "", false)
+	if result != nil {
+		t.Errorf("Logs() result = %v, want nil", result)
+	}
+	if err == nil {
+		t.Fatal("Logs() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "not implemented") {
+		t.Errorf("Logs() error = %q, want it to contain \"not implemented\"", err.Error())
+	}
+}
+
+func TestECSProvider_Stop_Stub(t *testing.T) {
+	t.Parallel()
+	p := NewECSProvider(&fakeECSClient{}, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	err := p.Stop(context.Background(), StopOpts{})
+	if err == nil {
+		t.Fatal("Stop() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "not implemented") {
+		t.Errorf("Stop() error = %q, want it to contain \"not implemented\"", err.Error())
+	}
+}
+
+func TestECSProvider_ReadFile_Stub(t *testing.T) {
+	t.Parallel()
+	p := NewECSProvider(&fakeECSClient{}, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	result, err := p.ReadFile(context.Background(), ReadFileOpts{})
+	if result != nil {
+		t.Errorf("ReadFile() result = %v, want nil", result)
+	}
+	if err == nil {
+		t.Fatal("ReadFile() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "not implemented") {
+		t.Errorf("ReadFile() error = %q, want it to contain \"not implemented\"", err.Error())
+	}
+}

--- a/internal/provider/ecs_test.go
+++ b/internal/provider/ecs_test.go
@@ -1850,6 +1850,37 @@ func TestECSProvider_ReadFile_EmptyRunID(t *testing.T) {
 	}
 }
 
+func TestECSProvider_ReadFile_RunIDTraversal(t *testing.T) {
+	t.Parallel()
+	p := NewECSProvider(&fakeECSClient{}, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+
+	cases := []struct {
+		name  string
+		runID string
+	}{
+		{"dot-dot", "../../other-user/secret"},
+		{"forward-slash", "foo/bar"},
+		{"backslash", "foo\\bar"},
+		{"dot-dot-only", ".."},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := p.ReadFile(context.Background(), ReadFileOpts{
+				RunID:    tc.runID,
+				Path:     ".orc/audit/foo.json",
+				Metadata: map[string]string{"artifacts_bucket": "my-bucket"},
+			})
+			if err == nil {
+				t.Fatal("ReadFile() error = nil, want non-nil")
+			}
+			if !strings.Contains(err.Error(), "invalid run ID") {
+				t.Errorf("ReadFile() error = %q, want it to contain \"invalid run ID\"", err.Error())
+			}
+		})
+	}
+}
+
 func TestECSProvider_ReadFile_NilResponse(t *testing.T) {
 	t.Parallel()
 	// fakeS3Client with zero fields returns (nil, nil) from GetObject — triggers nil-response guard.

--- a/internal/provider/ecs_test.go
+++ b/internal/provider/ecs_test.go
@@ -22,9 +22,11 @@ type fakeECSClient struct {
 	runTaskOutput *ecs.RunTaskOutput
 	runTaskErr    error
 
-	describeTasksInput  *ecs.DescribeTasksInput
-	describeTasksOutput *ecs.DescribeTasksOutput
-	describeTasksErr    error
+	describeTasksInput   *ecs.DescribeTasksInput
+	describeTasksOutput  *ecs.DescribeTasksOutput
+	describeTasksErr     error
+	describeTasksInputs  []*ecs.DescribeTasksInput
+	describeTasksOutputs []*ecs.DescribeTasksOutput
 }
 
 func (f *fakeECSClient) RunTask(ctx context.Context, params *ecs.RunTaskInput, optFns ...func(*ecs.Options)) (*ecs.RunTaskOutput, error) {
@@ -39,7 +41,18 @@ func (f *fakeECSClient) RunTask(ctx context.Context, params *ecs.RunTaskInput, o
 }
 func (f *fakeECSClient) DescribeTasks(ctx context.Context, params *ecs.DescribeTasksInput, optFns ...func(*ecs.Options)) (*ecs.DescribeTasksOutput, error) {
 	f.describeTasksInput = params
-	return f.describeTasksOutput, f.describeTasksErr
+	f.describeTasksInputs = append(f.describeTasksInputs, params)
+	if f.describeTasksErr != nil {
+		return nil, f.describeTasksErr
+	}
+	if len(f.describeTasksOutputs) > 0 {
+		idx := len(f.describeTasksInputs) - 1
+		if idx < len(f.describeTasksOutputs) {
+			return f.describeTasksOutputs[idx], nil
+		}
+		return f.describeTasksOutputs[len(f.describeTasksOutputs)-1], nil
+	}
+	return f.describeTasksOutput, nil
 }
 func (f *fakeECSClient) StopTask(ctx context.Context, params *ecs.StopTaskInput, optFns ...func(*ecs.Options)) (*ecs.StopTaskOutput, error) {
 	return nil, nil
@@ -49,14 +62,18 @@ type fakeCloudWatchLogsClient struct {
 	getLogEventsInputs  []*cloudwatchlogs.GetLogEventsInput
 	getLogEventsOutputs []*cloudwatchlogs.GetLogEventsOutput
 	getLogEventsErr     error
+	getLogEventsErrs    []error
 }
 
 func (f *fakeCloudWatchLogsClient) GetLogEvents(ctx context.Context, params *cloudwatchlogs.GetLogEventsInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.GetLogEventsOutput, error) {
 	f.getLogEventsInputs = append(f.getLogEventsInputs, params)
+	idx := len(f.getLogEventsInputs) - 1
+	if idx < len(f.getLogEventsErrs) && f.getLogEventsErrs[idx] != nil {
+		return nil, f.getLogEventsErrs[idx]
+	}
 	if f.getLogEventsErr != nil {
 		return nil, f.getLogEventsErr
 	}
-	idx := len(f.getLogEventsInputs) - 1
 	if idx < len(f.getLogEventsOutputs) {
 		return f.getLogEventsOutputs[idx], nil
 	}
@@ -680,19 +697,212 @@ func TestECSProvider_Logs_APIError(t *testing.T) {
 	}
 }
 
-func TestECSProvider_Logs_FollowNotImplemented(t *testing.T) {
+func TestECSProvider_Logs_Follow_TaskStops(t *testing.T) {
+	t.Parallel()
+	fakeLogs := &fakeCloudWatchLogsClient{
+		getLogEventsOutputs: []*cloudwatchlogs.GetLogEventsOutput{
+			{
+				Events:           []cwltypes.OutputLogEvent{{Message: aws.String("follow line 1\n")}},
+				NextForwardToken: aws.String("tok1"),
+			},
+			{
+				// Same token — follow mode does NOT stop on same token
+				Events:           []cwltypes.OutputLogEvent{{Message: aws.String("follow line 2\n")}},
+				NextForwardToken: aws.String("tok1"),
+			},
+		},
+	}
+	fakeECS := &fakeECSClient{
+		describeTasksOutputs: []*ecs.DescribeTasksOutput{
+			{Tasks: []ecstypes.Task{{LastStatus: aws.String("RUNNING")}}},
+			{Tasks: []ecstypes.Task{{LastStatus: aws.String("STOPPED")}}},
+		},
+	}
+	p := NewECSProvider(fakeECS, fakeLogs, &fakeS3Client{}, testHordeConfig())
+	p.pollInterval = time.Millisecond
+
+	reader, err := p.Logs(context.Background(), "arn:aws:ecs:us-east-1:123456789012:task/horde/abc123", true)
+	if err != nil {
+		t.Fatalf("Logs() error = %v, want nil", err)
+	}
+	defer reader.Close()
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	want := "follow line 1\nfollow line 2\n"
+	if string(data) != want {
+		t.Errorf("Logs output = %q, want %q", string(data), want)
+	}
+
+	if len(fakeLogs.getLogEventsInputs) < 1 {
+		t.Fatal("GetLogEvents was not called")
+	}
+	in := fakeLogs.getLogEventsInputs[0]
+	if *in.LogGroupName != "/ecs/horde-worker" {
+		t.Errorf("LogGroupName = %q, want %q", *in.LogGroupName, "/ecs/horde-worker")
+	}
+	if *in.LogStreamName != "ecs/horde-worker/abc123" {
+		t.Errorf("LogStreamName = %q, want %q", *in.LogStreamName, "ecs/horde-worker/abc123")
+	}
+}
+
+func TestECSProvider_Logs_Follow_ContextCancel(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	fakeLogs := &fakeCloudWatchLogsClient{
+		getLogEventsOutputs: []*cloudwatchlogs.GetLogEventsOutput{
+			{
+				Events:           []cwltypes.OutputLogEvent{{Message: aws.String("line 1\n")}},
+				NextForwardToken: aws.String("tok1"),
+			},
+			// remaining calls return empty (default)
+		},
+	}
+	fakeECS := &fakeECSClient{
+		describeTasksOutputs: []*ecs.DescribeTasksOutput{
+			{Tasks: []ecstypes.Task{{LastStatus: aws.String("RUNNING")}}},
+		},
+	}
+	p := NewECSProvider(fakeECS, fakeLogs, &fakeS3Client{}, testHordeConfig())
+	p.pollInterval = time.Millisecond
+
+	reader, err := p.Logs(ctx, "arn:aws:ecs:us-east-1:123456789012:task/horde/abc123", true)
+	if err != nil {
+		t.Fatalf("Logs() error = %v, want nil", err)
+	}
+
+	buf := make([]byte, 64)
+	n, err := reader.Read(buf)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if string(buf[:n]) != "line 1\n" {
+		t.Errorf("Read() = %q, want %q", string(buf[:n]), "line 1\n")
+	}
+
+	cancel()
+
+	_, err = io.ReadAll(reader)
+	if err != nil {
+		t.Errorf("ReadAll() after cancel error = %v, want nil", err)
+	}
+
+	// reader.Close() must complete without hanging
+	reader.Close()
+}
+
+func TestECSProvider_Logs_Follow_GetLogEventsError(t *testing.T) {
+	t.Parallel()
+	fakeLogs := &fakeCloudWatchLogsClient{
+		getLogEventsOutputs: []*cloudwatchlogs.GetLogEventsOutput{
+			{
+				Events:           []cwltypes.OutputLogEvent{{Message: aws.String("line 1\n")}},
+				NextForwardToken: aws.String("tok1"),
+			},
+		},
+		getLogEventsErrs: []error{nil, fmt.Errorf("throttling")},
+	}
+	fakeECS := &fakeECSClient{
+		describeTasksOutputs: []*ecs.DescribeTasksOutput{
+			{Tasks: []ecstypes.Task{{LastStatus: aws.String("RUNNING")}}},
+		},
+	}
+	p := NewECSProvider(fakeECS, fakeLogs, &fakeS3Client{}, testHordeConfig())
+	p.pollInterval = time.Millisecond
+
+	reader, err := p.Logs(context.Background(), "arn:aws:ecs:us-east-1:123456789012:task/horde/abc123", true)
+	if err != nil {
+		t.Fatalf("Logs() error = %v, want nil", err)
+	}
+	defer reader.Close()
+
+	data, err := io.ReadAll(reader)
+	if err == nil {
+		t.Fatal("ReadAll() error = nil, want non-nil")
+	}
+	if !strings.Contains(string(data), "line 1") {
+		t.Errorf("data = %q, want it to contain \"line 1\"", string(data))
+	}
+	if !strings.Contains(err.Error(), "reading logs") {
+		t.Errorf("error = %q, want it to contain \"reading logs\"", err.Error())
+	}
+}
+
+func TestECSProvider_Logs_Follow_EmptyTaskID(t *testing.T) {
 	t.Parallel()
 	p := NewECSProvider(&fakeECSClient{}, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
-	result, err := p.Logs(context.Background(), "task-arn", true)
+	p.pollInterval = time.Millisecond
+
+	result, err := p.Logs(context.Background(), "arn:aws:ecs:us-east-1:123:task/horde/", true)
 	if result != nil {
 		t.Errorf("Logs() result = %v, want nil", result)
 	}
 	if err == nil {
 		t.Fatal("Logs() error = nil, want non-nil")
 	}
-	if !strings.Contains(err.Error(), "follow mode not implemented") {
-		t.Errorf("error = %q, want it to contain \"follow mode not implemented\"", err.Error())
+	if !strings.Contains(err.Error(), "empty task ID") {
+		t.Errorf("error = %q, want it to contain \"empty task ID\"", err.Error())
 	}
+}
+
+func TestECSProvider_Logs_Follow_NewlineHandling(t *testing.T) {
+	t.Parallel()
+	fakeLogs := &fakeCloudWatchLogsClient{
+		getLogEventsOutputs: []*cloudwatchlogs.GetLogEventsOutput{
+			{
+				Events: []cwltypes.OutputLogEvent{
+					{Message: aws.String("no newline")},
+					{Message: aws.String("has newline\n")},
+				},
+				// nil NextForwardToken
+			},
+		},
+	}
+	fakeECS := &fakeECSClient{
+		describeTasksOutputs: []*ecs.DescribeTasksOutput{
+			{Tasks: []ecstypes.Task{{LastStatus: aws.String("STOPPED")}}},
+		},
+	}
+	p := NewECSProvider(fakeECS, fakeLogs, &fakeS3Client{}, testHordeConfig())
+	p.pollInterval = time.Millisecond
+
+	reader, err := p.Logs(context.Background(), "arn:aws:ecs:us-east-1:123456789012:task/horde/abc123", true)
+	if err != nil {
+		t.Fatalf("Logs() error = %v, want nil", err)
+	}
+	defer reader.Close()
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	want := "no newline\nhas newline\n"
+	if string(data) != want {
+		t.Errorf("Logs output = %q, want %q", string(data), want)
+	}
+}
+
+func TestECSProvider_Logs_Follow_CloseStopsGoroutine(t *testing.T) {
+	t.Parallel()
+	fakeECS := &fakeECSClient{
+		describeTasksOutputs: []*ecs.DescribeTasksOutput{
+			{Tasks: []ecstypes.Task{{LastStatus: aws.String("RUNNING")}}},
+		},
+	}
+	p := NewECSProvider(fakeECS, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	p.pollInterval = time.Millisecond
+
+	reader, err := p.Logs(context.Background(), "arn:aws:ecs:us-east-1:123456789012:task/horde/abc123", true)
+	if err != nil {
+		t.Fatalf("Logs() error = %v, want nil", err)
+	}
+
+	// Close must return without hanging — confirms goroutine exits
+	reader.Close()
 }
 
 func TestECSProvider_Logs_BareTaskID(t *testing.T) {

--- a/internal/provider/ecs_test.go
+++ b/internal/provider/ecs_test.go
@@ -796,6 +796,8 @@ func TestECSProvider_Logs_Follow_LogStreamNotCreated(t *testing.T) {
 	}
 	fakeECS := &fakeECSClient{
 		describeTasksOutputs: []*ecs.DescribeTasksOutput{
+			{Tasks: []ecstypes.Task{{LastStatus: aws.String("RUNNING")}}},
+			{Tasks: []ecstypes.Task{{LastStatus: aws.String("RUNNING")}}},
 			{Tasks: []ecstypes.Task{{LastStatus: aws.String("STOPPED")}}},
 		},
 	}
@@ -818,6 +820,74 @@ func TestECSProvider_Logs_Follow_LogStreamNotCreated(t *testing.T) {
 	if len(fakeLogs.getLogEventsInputs) != 3 {
 		t.Errorf("GetLogEvents called %d times, want 3", len(fakeLogs.getLogEventsInputs))
 	}
+}
+
+func TestECSProvider_Logs_Follow_LogStreamNotCreatedTaskStopped(t *testing.T) {
+	t.Parallel()
+	fakeLogs := &fakeCloudWatchLogsClient{
+		getLogEventsErr: &cwltypes.ResourceNotFoundException{Message: aws.String("The specified log stream does not exist.")},
+	}
+	fakeECS := &fakeECSClient{
+		describeTasksOutputs: []*ecs.DescribeTasksOutput{
+			{Tasks: []ecstypes.Task{{LastStatus: aws.String("STOPPED")}}},
+		},
+	}
+	p := NewECSProvider(fakeECS, fakeLogs, &fakeS3Client{}, testHordeConfig())
+	p.pollInterval = time.Millisecond
+
+	reader, err := p.Logs(context.Background(), "arn:aws:ecs:us-east-1:123456789012:task/horde/abc123", true)
+	if err != nil {
+		t.Fatalf("Logs() error = %v, want nil", err)
+	}
+	defer reader.Close()
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v, want nil (goroutine must exit cleanly when task stops during RNF)", err)
+	}
+	if len(data) != 0 {
+		t.Errorf("output = %q, want empty (no log stream was ever created)", string(data))
+	}
+	if len(fakeLogs.getLogEventsInputs) != 1 {
+		t.Errorf("GetLogEvents called %d times, want 1", len(fakeLogs.getLogEventsInputs))
+	}
+	if len(fakeECS.describeTasksInputs) != 1 {
+		t.Errorf("DescribeTasks called %d times, want 1", len(fakeECS.describeTasksInputs))
+	}
+}
+
+func TestECSProvider_Logs_Follow_LogStreamNotCreatedContextCancel(t *testing.T) {
+	t.Parallel()
+	fakeLogs := &fakeCloudWatchLogsClient{
+		getLogEventsErr: &cwltypes.ResourceNotFoundException{Message: aws.String("The specified log stream does not exist.")},
+	}
+	fakeECS := &fakeECSClient{
+		describeTasksOutputs: []*ecs.DescribeTasksOutput{
+			{Tasks: []ecstypes.Task{{LastStatus: aws.String("RUNNING")}}},
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	p := NewECSProvider(fakeECS, fakeLogs, &fakeS3Client{}, testHordeConfig())
+	p.pollInterval = time.Millisecond
+
+	reader, err := p.Logs(ctx, "arn:aws:ecs:us-east-1:123456789012:task/horde/abc123", true)
+	if err != nil {
+		t.Fatalf("Logs() error = %v, want nil", err)
+	}
+
+	// Let the goroutine make a few RNF + DescribeTasks iterations, then cancel.
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+
+	// ReadAll must complete (goroutine must not hang).
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Logf("ReadAll() error = %v (acceptable — context cancelled)", err)
+	}
+	_ = data
+
+	// reader.Close() must complete without hanging.
+	reader.Close()
 }
 
 func TestECSProvider_Logs_Follow_LogStreamNotCreatedOtherErrorStillFatal(t *testing.T) {

--- a/internal/provider/ecs_test.go
+++ b/internal/provider/ecs_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	cloudwatchlogs "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
@@ -18,6 +19,10 @@ type fakeECSClient struct {
 	runTaskInput  *ecs.RunTaskInput
 	runTaskOutput *ecs.RunTaskOutput
 	runTaskErr    error
+
+	describeTasksInput  *ecs.DescribeTasksInput
+	describeTasksOutput *ecs.DescribeTasksOutput
+	describeTasksErr    error
 }
 
 func (f *fakeECSClient) RunTask(ctx context.Context, params *ecs.RunTaskInput, optFns ...func(*ecs.Options)) (*ecs.RunTaskOutput, error) {
@@ -31,7 +36,8 @@ func (f *fakeECSClient) RunTask(ctx context.Context, params *ecs.RunTaskInput, o
 	return &ecs.RunTaskOutput{}, nil
 }
 func (f *fakeECSClient) DescribeTasks(ctx context.Context, params *ecs.DescribeTasksInput, optFns ...func(*ecs.Options)) (*ecs.DescribeTasksOutput, error) {
-	return nil, nil
+	f.describeTasksInput = params
+	return f.describeTasksOutput, f.describeTasksErr
 }
 func (f *fakeECSClient) StopTask(ctx context.Context, params *ecs.StopTaskInput, optFns ...func(*ecs.Options)) (*ecs.StopTaskOutput, error) {
 	return nil, nil
@@ -275,18 +281,251 @@ func TestECSProvider_Launch_EmptyOpts(t *testing.T) {
 	}
 }
 
-func TestECSProvider_Status_Stub(t *testing.T) {
+func TestECSProvider_Status_Running(t *testing.T) {
 	t.Parallel()
-	p := NewECSProvider(&fakeECSClient{}, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
-	result, err := p.Status(context.Background(), "")
-	if result != nil {
-		t.Errorf("Status() result = %v, want nil", result)
+	started := time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC)
+	instanceID := "arn:aws:ecs:us-east-1:123456789012:task/horde/abc123"
+	fake := &fakeECSClient{
+		describeTasksOutput: &ecs.DescribeTasksOutput{
+			Tasks: []ecstypes.Task{
+				{
+					LastStatus: aws.String("RUNNING"),
+					StartedAt:  &started,
+				},
+			},
+		},
 	}
+	p := NewECSProvider(fake, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	result, err := p.Status(context.Background(), instanceID)
+	if err != nil {
+		t.Fatalf("Status() error = %v, want nil", err)
+	}
+	if result.State != "running" {
+		t.Errorf("State = %q, want \"running\"", result.State)
+	}
+	if result.ExitCode != nil {
+		t.Errorf("ExitCode = %v, want nil", result.ExitCode)
+	}
+	if result.StartedAt != started {
+		t.Errorf("StartedAt = %v, want %v", result.StartedAt, started)
+	}
+	if result.FinishedAt != nil {
+		t.Errorf("FinishedAt = %v, want nil", result.FinishedAt)
+	}
+	// Verify DescribeTasksInput
+	if fake.describeTasksInput == nil {
+		t.Fatal("DescribeTasks was not called")
+	}
+	if *fake.describeTasksInput.Cluster != testHordeConfig().ClusterARN {
+		t.Errorf("Cluster = %q, want %q", *fake.describeTasksInput.Cluster, testHordeConfig().ClusterARN)
+	}
+	if len(fake.describeTasksInput.Tasks) != 1 || fake.describeTasksInput.Tasks[0] != instanceID {
+		t.Errorf("Tasks = %v, want [%q]", fake.describeTasksInput.Tasks, instanceID)
+	}
+}
+
+func TestECSProvider_Status_Stopped(t *testing.T) {
+	t.Parallel()
+	started := time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC)
+	stopped := time.Date(2025, 1, 15, 11, 0, 0, 0, time.UTC)
+	exitCode := int32(0)
+	fake := &fakeECSClient{
+		describeTasksOutput: &ecs.DescribeTasksOutput{
+			Tasks: []ecstypes.Task{
+				{
+					LastStatus: aws.String("STOPPED"),
+					StartedAt:  &started,
+					StoppedAt:  &stopped,
+					Containers: []ecstypes.Container{
+						{ExitCode: &exitCode},
+					},
+				},
+			},
+		},
+	}
+	p := NewECSProvider(fake, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	result, err := p.Status(context.Background(), "task-arn")
+	if err != nil {
+		t.Fatalf("Status() error = %v, want nil", err)
+	}
+	if result.State != "stopped" {
+		t.Errorf("State = %q, want \"stopped\"", result.State)
+	}
+	if result.ExitCode == nil || *result.ExitCode != 0 {
+		t.Errorf("ExitCode = %v, want 0", result.ExitCode)
+	}
+	if result.FinishedAt == nil || *result.FinishedAt != stopped {
+		t.Errorf("FinishedAt = %v, want %v", result.FinishedAt, stopped)
+	}
+}
+
+func TestECSProvider_Status_StoppedNonZeroExit(t *testing.T) {
+	t.Parallel()
+	exitCode := int32(1)
+	fake := &fakeECSClient{
+		describeTasksOutput: &ecs.DescribeTasksOutput{
+			Tasks: []ecstypes.Task{
+				{
+					LastStatus: aws.String("STOPPED"),
+					Containers: []ecstypes.Container{
+						{ExitCode: &exitCode},
+					},
+				},
+			},
+		},
+	}
+	p := NewECSProvider(fake, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	result, err := p.Status(context.Background(), "task-arn")
+	if err != nil {
+		t.Fatalf("Status() error = %v, want nil", err)
+	}
+	if result.ExitCode == nil || *result.ExitCode != 1 {
+		t.Errorf("ExitCode = %v, want 1", result.ExitCode)
+	}
+}
+
+func TestECSProvider_Status_UnknownStatus(t *testing.T) {
+	t.Parallel()
+	fake := &fakeECSClient{
+		describeTasksOutput: &ecs.DescribeTasksOutput{
+			Tasks: []ecstypes.Task{
+				{LastStatus: aws.String("PROVISIONING")},
+			},
+		},
+	}
+	p := NewECSProvider(fake, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	result, err := p.Status(context.Background(), "task-arn")
+	if err != nil {
+		t.Fatalf("Status() error = %v, want nil", err)
+	}
+	if result.State != "unknown" {
+		t.Errorf("State = %q, want \"unknown\"", result.State)
+	}
+}
+
+func TestECSProvider_Status_NilLastStatus(t *testing.T) {
+	t.Parallel()
+	fake := &fakeECSClient{
+		describeTasksOutput: &ecs.DescribeTasksOutput{
+			Tasks: []ecstypes.Task{
+				{LastStatus: nil},
+			},
+		},
+	}
+	p := NewECSProvider(fake, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	result, err := p.Status(context.Background(), "task-arn")
+	if err != nil {
+		t.Fatalf("Status() error = %v, want nil", err)
+	}
+	if result.State != "unknown" {
+		t.Errorf("State = %q, want \"unknown\"", result.State)
+	}
+}
+
+func TestECSProvider_Status_NoContainers(t *testing.T) {
+	t.Parallel()
+	fake := &fakeECSClient{
+		describeTasksOutput: &ecs.DescribeTasksOutput{
+			Tasks: []ecstypes.Task{
+				{
+					LastStatus: aws.String("STOPPED"),
+					Containers: []ecstypes.Container{},
+				},
+			},
+		},
+	}
+	p := NewECSProvider(fake, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	result, err := p.Status(context.Background(), "task-arn")
+	if err != nil {
+		t.Fatalf("Status() error = %v, want nil", err)
+	}
+	if result.ExitCode != nil {
+		t.Errorf("ExitCode = %v, want nil", result.ExitCode)
+	}
+}
+
+func TestECSProvider_Status_DescribeTasksError(t *testing.T) {
+	t.Parallel()
+	fake := &fakeECSClient{describeTasksErr: fmt.Errorf("AccessDeniedException: not authorized")}
+	p := NewECSProvider(fake, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	_, err := p.Status(context.Background(), "task-arn")
 	if err == nil {
 		t.Fatal("Status() error = nil, want non-nil")
 	}
-	if !strings.Contains(err.Error(), "not implemented") {
-		t.Errorf("Status() error = %q, want it to contain \"not implemented\"", err.Error())
+	if !strings.Contains(err.Error(), "describing ECS task") {
+		t.Errorf("error = %q, want it to contain \"describing ECS task\"", err.Error())
+	}
+}
+
+func TestECSProvider_Status_Failure(t *testing.T) {
+	t.Parallel()
+	fake := &fakeECSClient{
+		describeTasksOutput: &ecs.DescribeTasksOutput{
+			Failures: []ecstypes.Failure{{Reason: aws.String("MISSING")}},
+		},
+	}
+	p := NewECSProvider(fake, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	_, err := p.Status(context.Background(), "task-arn")
+	if err == nil {
+		t.Fatal("Status() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "describing ECS task") {
+		t.Errorf("error = %q, want it to contain \"describing ECS task\"", err.Error())
+	}
+	if !strings.Contains(err.Error(), "MISSING") {
+		t.Errorf("error = %q, want it to contain \"MISSING\"", err.Error())
+	}
+}
+
+func TestECSProvider_Status_FailureNilReason(t *testing.T) {
+	t.Parallel()
+	fake := &fakeECSClient{
+		describeTasksOutput: &ecs.DescribeTasksOutput{
+			Failures: []ecstypes.Failure{{}},
+		},
+	}
+	p := NewECSProvider(fake, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	_, err := p.Status(context.Background(), "task-arn")
+	if err == nil {
+		t.Fatal("Status() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "describing ECS task") {
+		t.Errorf("error = %q, want it to contain \"describing ECS task\"", err.Error())
+	}
+}
+
+func TestECSProvider_Status_NoTasks(t *testing.T) {
+	t.Parallel()
+	fake := &fakeECSClient{
+		describeTasksOutput: &ecs.DescribeTasksOutput{
+			Tasks:    []ecstypes.Task{},
+			Failures: []ecstypes.Failure{},
+		},
+	}
+	p := NewECSProvider(fake, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	_, err := p.Status(context.Background(), "task-arn")
+	if err == nil {
+		t.Fatal("Status() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "task not found") {
+		t.Errorf("error = %q, want it to contain \"task not found\"", err.Error())
+	}
+}
+
+func TestECSProvider_Status_NilResponse(t *testing.T) {
+	t.Parallel()
+	// Both describeTasksOutput and describeTasksErr are zero (nil) — tests nil response guard.
+	fake := &fakeECSClient{}
+	p := NewECSProvider(fake, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	_, err := p.Status(context.Background(), "task-arn")
+	if err == nil {
+		t.Fatal("Status() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "describing ECS task") {
+		t.Errorf("error = %q, want it to contain \"describing ECS task\"", err.Error())
+	}
+	if !strings.Contains(err.Error(), "nil response") {
+		t.Errorf("error = %q, want it to contain \"nil response\"", err.Error())
 	}
 }
 

--- a/internal/provider/ecs_test.go
+++ b/internal/provider/ecs_test.go
@@ -2,19 +2,33 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	cloudwatchlogs "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/jorge-barreto/horde/internal/config"
 )
 
-type fakeECSClient struct{}
+type fakeECSClient struct {
+	runTaskInput  *ecs.RunTaskInput
+	runTaskOutput *ecs.RunTaskOutput
+	runTaskErr    error
+}
 
 func (f *fakeECSClient) RunTask(ctx context.Context, params *ecs.RunTaskInput, optFns ...func(*ecs.Options)) (*ecs.RunTaskOutput, error) {
-	return nil, nil
+	f.runTaskInput = params
+	if f.runTaskErr != nil {
+		return nil, f.runTaskErr
+	}
+	if f.runTaskOutput != nil {
+		return f.runTaskOutput, nil
+	}
+	return &ecs.RunTaskOutput{}, nil
 }
 func (f *fakeECSClient) DescribeTasks(ctx context.Context, params *ecs.DescribeTasksInput, optFns ...func(*ecs.Options)) (*ecs.DescribeTasksOutput, error) {
 	return nil, nil
@@ -65,18 +79,199 @@ func TestECSProvider_InterfaceCompliance(t *testing.T) {
 	}
 }
 
-func TestECSProvider_Launch_NilResponse(t *testing.T) {
+func TestECSProvider_Launch_Success(t *testing.T) {
 	t.Parallel()
-	p := NewECSProvider(&fakeECSClient{}, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
-	result, err := p.Launch(context.Background(), LaunchOpts{})
-	if result != nil {
-		t.Errorf("Launch() result = %v, want nil", result)
+	taskARN := "arn:aws:ecs:us-east-1:123456789012:task/horde/abc123"
+	fake := &fakeECSClient{
+		runTaskOutput: &ecs.RunTaskOutput{
+			Tasks: []ecstypes.Task{
+				{TaskArn: aws.String(taskARN)},
+			},
+		},
 	}
+	p := NewECSProvider(fake, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	opts := LaunchOpts{
+		Repo:     "github.com/org/repo.git",
+		Ticket:   "PROJ-123",
+		Branch:   "main",
+		Workflow: "default",
+		RunID:    "k7m2xp4qr9n3",
+	}
+	result, err := p.Launch(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("Launch() error = %v, want nil", err)
+	}
+	if result.InstanceID != taskARN {
+		t.Errorf("InstanceID = %q, want %q", result.InstanceID, taskARN)
+	}
+	if result.Metadata["cluster_arn"] != "arn:aws:ecs:us-east-1:123456789012:cluster/horde" {
+		t.Errorf("Metadata[cluster_arn] = %q", result.Metadata["cluster_arn"])
+	}
+	if result.Metadata["log_group"] != "/ecs/horde-worker" {
+		t.Errorf("Metadata[log_group] = %q", result.Metadata["log_group"])
+	}
+	if result.Metadata["artifacts_bucket"] != "my-horde-artifacts" {
+		t.Errorf("Metadata[artifacts_bucket] = %q", result.Metadata["artifacts_bucket"])
+	}
+
+	// Verify RunTaskInput construction
+	in := fake.runTaskInput
+	if in == nil {
+		t.Fatal("RunTask was not called")
+	}
+	if *in.TaskDefinition != "arn:aws:ecs:us-east-1:123456789012:task-definition/horde-worker:1" {
+		t.Errorf("TaskDefinition = %q", *in.TaskDefinition)
+	}
+	if *in.Cluster != "arn:aws:ecs:us-east-1:123456789012:cluster/horde" {
+		t.Errorf("Cluster = %q", *in.Cluster)
+	}
+	if in.LaunchType != ecstypes.LaunchTypeFargate {
+		t.Errorf("LaunchType = %v", in.LaunchType)
+	}
+	if *in.Count != 1 {
+		t.Errorf("Count = %d, want 1", *in.Count)
+	}
+	vpc := in.NetworkConfiguration.AwsvpcConfiguration
+	if len(vpc.Subnets) == 0 || vpc.Subnets[0] != "subnet-abc" {
+		t.Errorf("Subnets = %v", vpc.Subnets)
+	}
+	if len(vpc.SecurityGroups) == 0 || vpc.SecurityGroups[0] != "sg-123" {
+		t.Errorf("SecurityGroups = %v", vpc.SecurityGroups)
+	}
+	if vpc.AssignPublicIp != ecstypes.AssignPublicIpEnabled {
+		t.Errorf("AssignPublicIp = %v", vpc.AssignPublicIp)
+	}
+	overrides := in.Overrides.ContainerOverrides
+	if len(overrides) != 1 {
+		t.Fatalf("ContainerOverrides len = %d, want 1", len(overrides))
+	}
+	if *overrides[0].Name != "horde-worker" {
+		t.Errorf("ContainerOverride Name = %q", *overrides[0].Name)
+	}
+	envMap := make(map[string]string)
+	for _, kv := range overrides[0].Environment {
+		envMap[*kv.Name] = *kv.Value
+	}
+	wantEnv := map[string]string{
+		"REPO_URL":         "github.com/org/repo.git",
+		"TICKET":           "PROJ-123",
+		"BRANCH":           "main",
+		"WORKFLOW":         "default",
+		"RUN_ID":           "k7m2xp4qr9n3",
+		"ARTIFACTS_BUCKET": "my-horde-artifacts",
+	}
+	for k, v := range wantEnv {
+		if envMap[k] != v {
+			t.Errorf("env[%s] = %q, want %q", k, envMap[k], v)
+		}
+	}
+	tagMap := make(map[string]string)
+	for _, tag := range in.Tags {
+		tagMap[*tag.Key] = *tag.Value
+	}
+	if tagMap["horde-run-id"] != "k7m2xp4qr9n3" {
+		t.Errorf("tag horde-run-id = %q", tagMap["horde-run-id"])
+	}
+	if tagMap["horde-ticket"] != "PROJ-123" {
+		t.Errorf("tag horde-ticket = %q", tagMap["horde-ticket"])
+	}
+}
+
+func TestECSProvider_Launch_RunTaskError(t *testing.T) {
+	t.Parallel()
+	fake := &fakeECSClient{runTaskErr: fmt.Errorf("AccessDeniedException: not authorized")}
+	p := NewECSProvider(fake, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	_, err := p.Launch(context.Background(), LaunchOpts{})
 	if err == nil {
 		t.Fatal("Launch() error = nil, want non-nil")
 	}
 	if !strings.Contains(err.Error(), "launching ECS task") {
-		t.Errorf("Launch() error = %q, want it to contain \"launching ECS task\"", err.Error())
+		t.Errorf("error = %q, want it to contain \"launching ECS task\"", err.Error())
+	}
+}
+
+func TestECSProvider_Launch_Failure(t *testing.T) {
+	t.Parallel()
+	fake := &fakeECSClient{
+		runTaskOutput: &ecs.RunTaskOutput{
+			Failures: []ecstypes.Failure{{Reason: aws.String("RESOURCE:ENI")}},
+		},
+	}
+	p := NewECSProvider(fake, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	_, err := p.Launch(context.Background(), LaunchOpts{})
+	if err == nil {
+		t.Fatal("Launch() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "launching ECS task") {
+		t.Errorf("error = %q, want it to contain \"launching ECS task\"", err.Error())
+	}
+	if !strings.Contains(err.Error(), "RESOURCE:ENI") {
+		t.Errorf("error = %q, want it to contain \"RESOURCE:ENI\"", err.Error())
+	}
+}
+
+func TestECSProvider_Launch_NoTasks(t *testing.T) {
+	t.Parallel()
+	fake := &fakeECSClient{
+		runTaskOutput: &ecs.RunTaskOutput{Tasks: []ecstypes.Task{}},
+	}
+	p := NewECSProvider(fake, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	_, err := p.Launch(context.Background(), LaunchOpts{})
+	if err == nil {
+		t.Fatal("Launch() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "no task returned") {
+		t.Errorf("error = %q, want it to contain \"no task returned\"", err.Error())
+	}
+}
+
+func TestECSProvider_Launch_NilTaskArn(t *testing.T) {
+	t.Parallel()
+	fake := &fakeECSClient{
+		runTaskOutput: &ecs.RunTaskOutput{
+			Tasks: []ecstypes.Task{{}}, // TaskArn is nil
+		},
+	}
+	p := NewECSProvider(fake, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	_, err := p.Launch(context.Background(), LaunchOpts{})
+	if err == nil {
+		t.Fatal("Launch() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "task ARN is nil") {
+		t.Errorf("error = %q, want it to contain \"task ARN is nil\"", err.Error())
+	}
+}
+
+func TestECSProvider_Launch_EmptyOpts(t *testing.T) {
+	t.Parallel()
+	taskARN := "arn:aws:ecs:us-east-1:123456789012:task/horde/empty"
+	fake := &fakeECSClient{
+		runTaskOutput: &ecs.RunTaskOutput{
+			Tasks: []ecstypes.Task{{TaskArn: aws.String(taskARN)}},
+		},
+	}
+	p := NewECSProvider(fake, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	result, err := p.Launch(context.Background(), LaunchOpts{})
+	if err != nil {
+		t.Fatalf("Launch() error = %v, want nil", err)
+	}
+	if result.InstanceID != taskARN {
+		t.Errorf("InstanceID = %q, want %q", result.InstanceID, taskARN)
+	}
+	// Provider does not validate opts — empty strings are passed through
+	in := fake.runTaskInput
+	envMap := make(map[string]string)
+	for _, kv := range in.Overrides.ContainerOverrides[0].Environment {
+		envMap[*kv.Name] = *kv.Value
+	}
+	for _, key := range []string{"REPO_URL", "TICKET", "BRANCH", "WORKFLOW", "RUN_ID"} {
+		if envMap[key] != "" {
+			t.Errorf("env[%s] = %q, want empty string", key, envMap[key])
+		}
+	}
+	// ARTIFACTS_BUCKET comes from config, not opts
+	if envMap["ARTIFACTS_BUCKET"] != "my-horde-artifacts" {
+		t.Errorf("env[ARTIFACTS_BUCKET] = %q, want \"my-horde-artifacts\"", envMap["ARTIFACTS_BUCKET"])
 	}
 }
 

--- a/internal/provider/ecs_test.go
+++ b/internal/provider/ecs_test.go
@@ -1271,7 +1271,7 @@ func TestECSProvider_ReadFile_BodyReadError(t *testing.T) {
 func TestECSProvider_ReadFile_EmptyPath(t *testing.T) {
 	t.Parallel()
 	p := NewECSProvider(&fakeECSClient{}, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
-	_, err := p.ReadFile(context.Background(), ReadFileOpts{Path: ""})
+	_, err := p.ReadFile(context.Background(), ReadFileOpts{RunID: "run-001", Path: ""})
 	if err == nil {
 		t.Fatal("ReadFile() error = nil, want non-nil")
 	}
@@ -1283,7 +1283,7 @@ func TestECSProvider_ReadFile_EmptyPath(t *testing.T) {
 func TestECSProvider_ReadFile_InvalidPrefix(t *testing.T) {
 	t.Parallel()
 	p := NewECSProvider(&fakeECSClient{}, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
-	_, err := p.ReadFile(context.Background(), ReadFileOpts{Path: "some/other/file.txt"})
+	_, err := p.ReadFile(context.Background(), ReadFileOpts{RunID: "run-001", Path: "some/other/file.txt"})
 	if err == nil {
 		t.Fatal("ReadFile() error = nil, want non-nil")
 	}
@@ -1295,7 +1295,7 @@ func TestECSProvider_ReadFile_InvalidPrefix(t *testing.T) {
 func TestECSProvider_ReadFile_BareOrcPrefix(t *testing.T) {
 	t.Parallel()
 	p := NewECSProvider(&fakeECSClient{}, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
-	_, err := p.ReadFile(context.Background(), ReadFileOpts{Path: ".orc/"})
+	_, err := p.ReadFile(context.Background(), ReadFileOpts{RunID: "run-001", Path: ".orc/"})
 	if err == nil {
 		t.Fatal("ReadFile() error = nil, want non-nil")
 	}
@@ -1349,5 +1349,21 @@ func TestECSProvider_ReadFile_EmptyBucketInMetadata(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "artifacts_bucket not found in metadata") {
 		t.Errorf("ReadFile() error = %q, want it to contain \"artifacts_bucket not found in metadata\"", err.Error())
+	}
+}
+
+func TestECSProvider_ReadFile_EmptyRunID(t *testing.T) {
+	t.Parallel()
+	p := NewECSProvider(&fakeECSClient{}, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	_, err := p.ReadFile(context.Background(), ReadFileOpts{
+		RunID:    "",
+		Path:     ".orc/audit/foo.json",
+		Metadata: map[string]string{"artifacts_bucket": "my-horde-artifacts"},
+	})
+	if err == nil {
+		t.Fatal("ReadFile() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "run ID is required") {
+		t.Errorf("ReadFile() error = %q, want it to contain \"run ID is required\"", err.Error())
 	}
 }

--- a/internal/provider/ecs_test.go
+++ b/internal/provider/ecs_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -14,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/jorge-barreto/horde/internal/config"
 )
 
@@ -91,9 +93,20 @@ func (f *fakeCloudWatchLogsClient) GetLogEvents(ctx context.Context, params *clo
 	return &cloudwatchlogs.GetLogEventsOutput{}, nil
 }
 
-type fakeS3Client struct{}
+type fakeS3Client struct {
+	getObjectInput  *s3.GetObjectInput
+	getObjectOutput *s3.GetObjectOutput
+	getObjectErr    error
+}
 
 func (f *fakeS3Client) GetObject(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	f.getObjectInput = params
+	if f.getObjectErr != nil {
+		return nil, f.getObjectErr
+	}
+	if f.getObjectOutput != nil {
+		return f.getObjectOutput, nil
+	}
 	return nil, nil
 }
 
@@ -1039,17 +1052,186 @@ func TestECSProvider_Stop_IgnoresResultsDir(t *testing.T) {
 	}
 }
 
-func TestECSProvider_ReadFile_Stub(t *testing.T) {
+func TestECSProvider_ReadFile_Success(t *testing.T) {
 	t.Parallel()
-	p := NewECSProvider(&fakeECSClient{}, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
-	result, err := p.ReadFile(context.Background(), ReadFileOpts{})
-	if result != nil {
-		t.Errorf("ReadFile() result = %v, want nil", result)
+	fake := &fakeS3Client{
+		getObjectOutput: &s3.GetObjectOutput{
+			Body: io.NopCloser(strings.NewReader(`{"ok":true}`)),
+		},
 	}
+	p := NewECSProvider(&fakeECSClient{}, &fakeCloudWatchLogsClient{}, fake, testHordeConfig())
+	data, err := p.ReadFile(context.Background(), ReadFileOpts{
+		RunID:    "k7m2xp4qr9n3",
+		Path:     ".orc/audit/PROJ-123/run-result.json",
+		Metadata: map[string]string{"artifacts_bucket": "my-horde-artifacts"},
+	})
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v, want nil", err)
+	}
+	if string(data) != `{"ok":true}` {
+		t.Errorf("ReadFile() data = %q, want %q", data, `{"ok":true}`)
+	}
+	if fake.getObjectInput == nil {
+		t.Fatal("GetObject was not called")
+	}
+	if *fake.getObjectInput.Bucket != "my-horde-artifacts" {
+		t.Errorf("Bucket = %q, want %q", *fake.getObjectInput.Bucket, "my-horde-artifacts")
+	}
+	if *fake.getObjectInput.Key != "horde-runs/k7m2xp4qr9n3/audit/PROJ-123/run-result.json" {
+		t.Errorf("Key = %q", *fake.getObjectInput.Key)
+	}
+}
+
+func TestECSProvider_ReadFile_ArtifactsPath(t *testing.T) {
+	t.Parallel()
+	fake := &fakeS3Client{
+		getObjectOutput: &s3.GetObjectOutput{
+			Body: io.NopCloser(strings.NewReader("hello")),
+		},
+	}
+	p := NewECSProvider(&fakeECSClient{}, &fakeCloudWatchLogsClient{}, fake, testHordeConfig())
+	_, err := p.ReadFile(context.Background(), ReadFileOpts{
+		RunID:    "run-002",
+		Path:     ".orc/artifacts/output.txt",
+		Metadata: map[string]string{"artifacts_bucket": "my-horde-artifacts"},
+	})
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v, want nil", err)
+	}
+	if fake.getObjectInput == nil {
+		t.Fatal("GetObject was not called")
+	}
+	if *fake.getObjectInput.Key != "horde-runs/run-002/artifacts/output.txt" {
+		t.Errorf("Key = %q, want %q", *fake.getObjectInput.Key, "horde-runs/run-002/artifacts/output.txt")
+	}
+}
+
+func TestECSProvider_ReadFile_NoSuchKey(t *testing.T) {
+	t.Parallel()
+	fake := &fakeS3Client{
+		getObjectErr: &s3types.NoSuchKey{Message: aws.String("key not found")},
+	}
+	p := NewECSProvider(&fakeECSClient{}, &fakeCloudWatchLogsClient{}, fake, testHordeConfig())
+	_, err := p.ReadFile(context.Background(), ReadFileOpts{
+		RunID:    "run-001",
+		Path:     ".orc/audit/foo.json",
+		Metadata: map[string]string{"artifacts_bucket": "my-horde-artifacts"},
+	})
 	if err == nil {
 		t.Fatal("ReadFile() error = nil, want non-nil")
 	}
-	if !strings.Contains(err.Error(), "not implemented") {
-		t.Errorf("ReadFile() error = %q, want it to contain \"not implemented\"", err.Error())
+	var notFound *FileNotFoundError
+	if !errors.As(err, &notFound) {
+		t.Errorf("ReadFile() error type = %T, want *FileNotFoundError", err)
+	}
+	if notFound.Path != ".orc/audit/foo.json" {
+		t.Errorf("FileNotFoundError.Path = %q, want %q", notFound.Path, ".orc/audit/foo.json")
+	}
+}
+
+func TestECSProvider_ReadFile_S3Error(t *testing.T) {
+	t.Parallel()
+	fake := &fakeS3Client{
+		getObjectErr: fmt.Errorf("AccessDenied"),
+	}
+	p := NewECSProvider(&fakeECSClient{}, &fakeCloudWatchLogsClient{}, fake, testHordeConfig())
+	_, err := p.ReadFile(context.Background(), ReadFileOpts{
+		RunID:    "run-001",
+		Path:     ".orc/audit/foo.json",
+		Metadata: map[string]string{"artifacts_bucket": "my-horde-artifacts"},
+	})
+	if err == nil {
+		t.Fatal("ReadFile() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "reading file from s3") {
+		t.Errorf("ReadFile() error = %q, want it to contain \"reading file from s3\"", err.Error())
+	}
+	var notFound *FileNotFoundError
+	if errors.As(err, &notFound) {
+		t.Errorf("ReadFile() error = %T, should NOT be *FileNotFoundError", err)
+	}
+}
+
+func TestECSProvider_ReadFile_EmptyPath(t *testing.T) {
+	t.Parallel()
+	p := NewECSProvider(&fakeECSClient{}, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	_, err := p.ReadFile(context.Background(), ReadFileOpts{Path: ""})
+	if err == nil {
+		t.Fatal("ReadFile() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "path is required") {
+		t.Errorf("ReadFile() error = %q, want it to contain \"path is required\"", err.Error())
+	}
+}
+
+func TestECSProvider_ReadFile_InvalidPrefix(t *testing.T) {
+	t.Parallel()
+	p := NewECSProvider(&fakeECSClient{}, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	_, err := p.ReadFile(context.Background(), ReadFileOpts{Path: "some/other/file.txt"})
+	if err == nil {
+		t.Fatal("ReadFile() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "path must start with") {
+		t.Errorf("ReadFile() error = %q, want it to contain \"path must start with\"", err.Error())
+	}
+}
+
+func TestECSProvider_ReadFile_BareOrcPrefix(t *testing.T) {
+	t.Parallel()
+	p := NewECSProvider(&fakeECSClient{}, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	_, err := p.ReadFile(context.Background(), ReadFileOpts{Path: ".orc/"})
+	if err == nil {
+		t.Fatal("ReadFile() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "path must include a filename") {
+		t.Errorf("ReadFile() error = %q, want it to contain \"path must include a filename\"", err.Error())
+	}
+}
+
+func TestECSProvider_ReadFile_NilMetadata(t *testing.T) {
+	t.Parallel()
+	p := NewECSProvider(&fakeECSClient{}, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	_, err := p.ReadFile(context.Background(), ReadFileOpts{
+		RunID:    "run-001",
+		Path:     ".orc/audit/foo.json",
+		Metadata: nil,
+	})
+	if err == nil {
+		t.Fatal("ReadFile() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "artifacts_bucket not found in metadata") {
+		t.Errorf("ReadFile() error = %q, want it to contain \"artifacts_bucket not found in metadata\"", err.Error())
+	}
+}
+
+func TestECSProvider_ReadFile_MissingBucketInMetadata(t *testing.T) {
+	t.Parallel()
+	p := NewECSProvider(&fakeECSClient{}, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	_, err := p.ReadFile(context.Background(), ReadFileOpts{
+		RunID:    "run-001",
+		Path:     ".orc/audit/foo.json",
+		Metadata: map[string]string{"log_group": "foo"},
+	})
+	if err == nil {
+		t.Fatal("ReadFile() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "artifacts_bucket not found in metadata") {
+		t.Errorf("ReadFile() error = %q, want it to contain \"artifacts_bucket not found in metadata\"", err.Error())
+	}
+}
+
+func TestECSProvider_ReadFile_EmptyBucketInMetadata(t *testing.T) {
+	t.Parallel()
+	p := NewECSProvider(&fakeECSClient{}, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	_, err := p.ReadFile(context.Background(), ReadFileOpts{
+		RunID:    "run-001",
+		Path:     ".orc/audit/foo.json",
+		Metadata: map[string]string{"artifacts_bucket": ""},
+	})
+	if err == nil {
+		t.Fatal("ReadFile() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "artifacts_bucket not found in metadata") {
+		t.Errorf("ReadFile() error = %q, want it to contain \"artifacts_bucket not found in metadata\"", err.Error())
 	}
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -42,7 +42,7 @@ type LaunchResult struct {
 
 // InstanceStatus describes the current state of a running or completed instance.
 type InstanceStatus struct {
-	State      string // running, stopped, unknown
+	State      string // pending, running, stopping, stopped, unknown
 	ExitCode   *int   // nil while running
 	StartedAt  time.Time
 	FinishedAt *time.Time // nil while running

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"path/filepath"
 	"time"
@@ -60,3 +61,15 @@ type StopOpts struct {
 	InstanceID string // container ID or ECS task ARN
 	ResultsDir string // per-run results directory for artifact copy (docker); empty to skip copy
 }
+
+// FileNotFoundError is returned when a requested file does not exist in the provider's storage.
+type FileNotFoundError struct {
+	Path string
+	Err  error
+}
+
+func (e *FileNotFoundError) Error() string {
+	return fmt.Sprintf("file not found: %s", e.Path)
+}
+
+func (e *FileNotFoundError) Unwrap() error { return e.Err }


### PR DESCRIPTION
## Summary

The ECS provider's `Status()` method mapped all non-running, non-stopped task states to `"unknown"`. This is a latent correctness bug: any future lazy-check path for ECS would treat transitional states (e.g. PROVISIONING, STOPPING) as terminal, writing `StatusFailed` to the store and permanently corrupting the run record. This PR fixes the mapping so transitional states are accurately represented, and documents the full set of valid state values.

## Changes

**`internal/provider/ecs.go`**
- Expanded the `Status()` switch to map PROVISIONING, PENDING, ACTIVATING → `"pending"` and DEPROVISIONING, STOPPING → `"stopping"`
- `"unknown"` is now reserved for nil `LastStatus` and genuinely unrecognized states

**`internal/provider/provider.go` / `SPEC.md`**
- Updated `InstanceStatus.State` comment from `// running, stopped, unknown` to `// pending, running, stopping, stopped, unknown`

**`internal/provider/ecs_test.go`**
- Updated `TestECSProvider_Status_UnknownStatus` → `TestECSProvider_Status_Provisioning` (PROVISIONING now expects `"pending"`)
- Added tests for PENDING, ACTIVATING (→ `"pending"`), DEPROVISIONING, STOPPING (→ `"stopping"`), and an unrecognized state (→ `"unknown"`)

## Testing

Six ECS `Status()` tests cover each transitional state group and forward-compatibility for unrecognized states. Existing tests for RUNNING, STOPPED, and nil `LastStatus` are unchanged and continue to pass.

---

*Ticket: `horde-954.23`*