### PR TITLE
horde-4ay.6: embed git SHA and build date in --version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,19 @@
 .PHONY: build install unit-test integration-test bootstrap-validate-test vet worker docker-build check e2e-up e2e-test e2e-down
 
+# Version metadata embedded via -ldflags. `version` falls back to the short
+# git describe (tag + offset + SHA) so dev builds are self-identifying;
+# release builds get the clean tag from goreleaser. `commit` and `buildDate`
+# are always from git / UTC now.
+VERSION    := $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+COMMIT     := $(shell git rev-parse --short HEAD 2>/dev/null || echo none)
+BUILD_DATE := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+LDFLAGS    := -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.buildDate=$(BUILD_DATE)
+
 build:
-	go build ./cmd/horde
+	go build -ldflags '$(LDFLAGS)' ./cmd/horde
 
 install:
-	go install ./cmd/horde
+	go install -ldflags '$(LDFLAGS)' ./cmd/horde
 
 # Fast tier: no Docker, no AWS. Must stay green on every commit.
 # Excludes cdk/ because it's a Node package; its node_modules/ contains

--- a/cmd/horde/main.go
+++ b/cmd/horde/main.go
@@ -27,6 +27,14 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
+// Overridden at build time via -ldflags '-X main.version=... -X main.commit=... -X main.buildDate=...'.
+// make build / make install populate these from git; goreleaser uses the tag.
+var (
+	version   = "dev"
+	commit    = "none"
+	buildDate = "unknown"
+)
+
 func main() {
 	// Merge .env from cwd into the process environment (real env wins). This
 	// lets commands like `horde bootstrap deploy` pick up CLAUDE_CODE_OAUTH_TOKEN
@@ -59,8 +67,9 @@ func setOutputs(app *cli.Command, w io.Writer) {
 
 func newApp() *cli.Command {
 	return &cli.Command{
-		Name:  "horde",
-		Usage: "Cloud launcher for orc workflows",
+		Name:    "horde",
+		Usage:   "Cloud launcher for orc workflows",
+		Version: fmt.Sprintf("%s (%s, built %s)", version, commit, buildDate),
 		Description: `horde runs orc workflows on ephemeral containers (Docker locally,
 ECS Fargate in AWS). It clones a repo, runs orc, collects results, and tears down.
 

--- a/cmd/horde/version_test.go
+++ b/cmd/horde/version_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+// Guards the --version output contract: "horde version <ver> (<commit>, built <date>)".
+// Downstream tooling (release notes, support bug reports) parses this — changing the
+// format requires updating consumers in lockstep.
+func TestVersionFlag(t *testing.T) {
+	origV, origC, origD := version, commit, buildDate
+	t.Cleanup(func() { version, commit, buildDate = origV, origC, origD })
+
+	version = "v0.2.0"
+	commit = "abc1234"
+	buildDate = "2026-04-21T12:00:00Z"
+
+	app := newApp()
+	var buf bytes.Buffer
+	setOutputs(app, &buf)
+
+	if err := app.Run(context.Background(), []string{"horde", "--version"}); err != nil {
+		t.Fatalf("running --version: %v", err)
+	}
+
+	got := buf.String()
+	want := "horde version v0.2.0 (abc1234, built 2026-04-21T12:00:00Z)"
+	if !strings.Contains(got, want) {
+		t.Fatalf("--version output:\n  got:  %q\n  want contains: %q", got, want)
+	}
+}
+
+// Defaults are the unset-ldflags fallback used by `go build ./cmd/horde` without
+// make. If these regress, dev builds lose version metadata silently.
+func TestVersionDefaults(t *testing.T) {
+	if version != "dev" || commit != "none" || buildDate != "unknown" {
+		t.Fatalf("defaults drifted: version=%q commit=%q buildDate=%q", version, commit, buildDate)
+	}
+}


### PR DESCRIPTION
## Summary
- `make build` / `make install` inject `version`, `commit`, `buildDate` via `-ldflags`
- `horde --version` now prints `horde version <ver> (<commit>, built <date>)`
- Dev fallback: `dev (none, built unknown)` when built without make
- Release builds will get the tag from goreleaser (4ay.3)

## Test plan
- [x] `make unit-test` — all green, new TestVersionFlag + TestVersionDefaults pass
- [x] `make vet` — clean
- [x] `make build && ./horde --version` — prints expected format
- [x] `go build -ldflags '-X main.version=v0.2.0 ...'` — injection works end-to-end