### PR TITLE
require --workflow at launch so cost data is captured

### DIFF
--- a/ORC_CONTRACT_EXPECTATIONS.md
+++ b/ORC_CONTRACT_EXPECTATIONS.md
@@ -24,13 +24,13 @@ What horde expects from orc at the interface boundary. This document does NOT sp
 
 ## Filesystem Contract
 
-orc writes artifacts and audit data relative to the project root (the cloned repo). Paths depend on whether a named workflow is used:
+orc writes artifacts and audit data relative to the project root (the cloned repo). horde always invokes orc with `-w <workflow>` (the `--workflow` flag is required at `horde launch`), so the only layout horde reads is the named-workflow form:
 
 | Layout | Artifacts | Audit |
 |--------|-----------|-------|
-| Default workflow | `.orc/artifacts/<ticket>/` | `.orc/audit/<ticket>/` |
 | Named workflow | `.orc/artifacts/<workflow>/<ticket>/` | `.orc/audit/<workflow>/<ticket>/` |
-| Default + named coexist | `.orc/artifacts/default/<ticket>/` | `.orc/audit/default/<ticket>/` |
+
+For reference, orc also supports an unnamed default-workflow layout (`.orc/audit/<ticket>/`), but horde does not exercise that path: launches without `--workflow` are rejected before orc is invoked.
 
 ### run-result.json
 
@@ -44,7 +44,7 @@ Expected contents:
   "exit_code": 0,
   "status": "completed",
   "ticket": "PROJ-123",
-  "workflow": "",
+  "workflow": "implement-ticket",
   "total_cost_usd": 4.52,
   "total_duration": "12m 34s",
   "phases": [
@@ -84,11 +84,7 @@ The worker environment must NOT have the `CLAUDECODE` environment variable set. 
 horde runs orc as:
 
 ```bash
-# Default workflow
-orc run <ticket> --auto --no-color [<extra-args>...]
-
-# Named workflow
 orc run -w <workflow> <ticket> --auto --no-color [<extra-args>...]
 ```
 
-`--auto` and `--no-color` are always present. Users can pass additional orc flags through horde using the `--` separator (e.g., `horde launch PROJ-123 -- --resume`). horde does not validate these flags — they are passed through opaquely.
+`-w`, `--auto`, and `--no-color` are always present. horde never relies on orc's default-workflow selection — `--workflow` is a required flag at `horde launch`, so the workflow segment in the audit/artifacts path is always known to horde. Users can pass additional orc flags through horde using the `--` separator (e.g., `horde launch --workflow implement-ticket PROJ-123 -- --resume`). horde does not validate these flags — they are passed through opaquely.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Attach the `CliUserManagedPolicyArn` output to the IAM user or role that will ru
 Once the stack is up and the image is pushed, from any repo whose git remote matches the slug:
 
 ```bash
-horde launch PROJ-123                 # provider auto-detects from SSM
+horde launch --workflow implement-ticket PROJ-123   # provider auto-detects from SSM
 horde status PROJ-123
 horde status PROJ-123 --json
 ```
@@ -113,10 +113,10 @@ npm run destroy
 All commands require a provider. For local Docker mode, pass `--provider docker`. Omit the flag when an AWS stack (provisioned via `horde bootstrap` or the [`@horde.io/cdk`](cdk/) construct) is deployed — horde auto-detects via SSM.
 
 ```bash
-# Launch a run
-horde launch --provider docker PROJ-123
-horde launch --provider docker PROJ-123 --branch feature/xyz
-horde launch --provider docker PROJ-123 --workflow bugfix --timeout 30m
+# Launch a run (--workflow is required)
+horde launch --provider docker --workflow implement-ticket PROJ-123
+horde launch --provider docker --workflow implement-ticket PROJ-123 --branch feature/xyz
+horde launch --provider docker --workflow bugfix PROJ-123 --timeout 30m
 
 # Monitor
 horde status <run-id>

--- a/SPEC.md
+++ b/SPEC.md
@@ -84,7 +84,7 @@ The status Lambda:
 ## CLI Commands
 
 ```
-horde launch [--branch=<branch>] [--workflow=<name>] [--timeout=<duration>] [--force] <ticket>
+horde launch --workflow=<name> [--branch=<branch>] [--timeout=<duration>] [--force] <ticket>
 horde status <run-id>
 horde logs <run-id> [--follow]
 horde kill <run-id>
@@ -106,14 +106,14 @@ Global flags:
 
 `--json` applies to: `status`, `results`, `list`, `health`. Output schemas are stable per major version.
 
-horde doesn't understand tickets, waves, or beads. `horde launch` runs `orc run <ticket> --auto --no-color` on an ephemeral instance. orc's workflow decides whether the ticket is an epic, whether to loop, etc.
+horde doesn't understand tickets, waves, or beads. `horde launch` runs `orc run -w <workflow> <ticket> --auto --no-color` on an ephemeral instance. The workflow is always passed explicitly — `--workflow` is a required flag — so audit and artifact paths are predictable (`.orc/audit/<workflow>/<ticket>/`). orc's workflow decides whether the ticket is an epic, whether to loop, etc.
 
 ## Run Lifecycle
 
 ### 1. Launch
 
 ```
-horde launch PROJ-123
+horde launch --workflow implement-ticket PROJ-123
 ```
 
 horde:
@@ -281,12 +281,8 @@ if [ -n "${BRANCH:-}" ]; then
     fi
 fi
 
-# Run orc
-if [ -n "${WORKFLOW:-}" ]; then
-    orc run -w "$WORKFLOW" "$TICKET" --auto --no-color
-else
-    orc run "$TICKET" --auto --no-color
-fi
+# Run orc — WORKFLOW is always set (horde rejects launches without --workflow).
+orc run -w "$WORKFLOW" "$TICKET" --auto --no-color
 EXIT_CODE=$?
 
 # Upload artifacts to S3 (ECS only — env vars are absent in docker mode)
@@ -320,7 +316,7 @@ The provider maps `LaunchOpts` to container environment variables:
 | `REPO_URL` | `LaunchOpts.Repo` | Normalized, no scheme (e.g., `github.com/org/repo.git`) |
 | `TICKET` | `LaunchOpts.Ticket` | Passed as argument to `orc run` |
 | `BRANCH` | `LaunchOpts.Branch` | Empty if not specified (entrypoint skips checkout) |
-| `WORKFLOW` | `LaunchOpts.Workflow` | Empty if default workflow |
+| `WORKFLOW` | `LaunchOpts.Workflow` | Always non-empty — `horde launch` requires `--workflow` |
 | `RUN_ID` | `LaunchOpts.RunID` | Used by S3 upload path (ECS only) |
 | `ARTIFACTS_BUCKET` | ECS config (SSM) | Absent in docker mode — triggers S3 upload when present |
 | `CLAUDE_CODE_OAUTH_TOKEN` | `.env` (docker) / Secrets Manager (ECS) | Claude CLI auth token (from `claude setup-token`) |
@@ -440,7 +436,7 @@ Lean schema for local testing. Not shared, not the production path.
 | repo | TEXT | Repository URL |
 | ticket | TEXT | ID passed to orc run |
 | branch | TEXT | Git branch (empty = repo default) |
-| workflow | TEXT | orc workflow name (empty = default) |
+| workflow | TEXT | orc workflow name (required at launch; empty only on legacy rows) |
 | provider | TEXT | docker |
 | instance_id | TEXT | Container ID |
 | metadata | TEXT | JSON-encoded map[string]string — provider-specific data (NULL if none) |
@@ -470,7 +466,7 @@ This is the production store — shared across the team. Every developer with AW
 | repo | S | Repository URL |
 | ticket | S | ID passed to orc run |
 | branch | S | Git branch (empty = repo default) |
-| workflow | S | orc workflow name (empty = default) |
+| workflow | S | orc workflow name (required at launch; empty only on legacy rows) |
 | provider | S | aws-ecs |
 | instance_id | S | ECS task ARN |
 | status | S | pending, running, success, failed, killed |

--- a/cmd/horde/main.go
+++ b/cmd/horde/main.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"sync"
 	"syscall"
 	"text/tabwriter"
@@ -118,8 +119,9 @@ kill some runs before launching more.`,
 				Usage: "Git branch to use",
 			},
 			&cli.StringFlag{
-				Name:  "workflow",
-				Usage: "Workflow to run",
+				Name:     "workflow",
+				Usage:    "Orc workflow to run (required, e.g. implement-ticket)",
+				Required: true,
 			},
 			&cli.DurationFlag{
 				Name:  "timeout",
@@ -139,9 +141,16 @@ kill some runs before launching more.`,
 			orcArgs := cmd.Args().Tail()
 
 			branch := cmd.String("branch")
-			workflow := cmd.String("workflow")
+			workflow := strings.TrimSpace(cmd.String("workflow"))
 			timeout := cmd.Duration("timeout")
 			force := cmd.Bool("force")
+
+			if workflow == "" {
+				return fmt.Errorf("--workflow is required (e.g. --workflow implement-ticket)")
+			}
+			if strings.ContainsAny(workflow, "/\\") || strings.Contains(workflow, "..") {
+				return fmt.Errorf("--workflow %q is invalid: must not contain '/', '\\', or '..'", workflow)
+			}
 
 			prov, st, maxConcurrent, provName, awsCfg, cleanup, err := initProviderAndStore(ctx, cmd)
 			if err != nil {
@@ -1141,6 +1150,8 @@ func printRunStatus(run *store.Run) {
 	fmt.Printf("Duration:    %s\n", duration)
 	if run.TotalCostUSD != nil {
 		fmt.Printf("Cost:        $%.2f\n", *run.TotalCostUSD)
+	} else {
+		fmt.Printf("Cost:        -\n")
 	}
 	fmt.Printf("Launched by: %s\n", run.LaunchedBy)
 	if homeDir, err := os.UserHomeDir(); err == nil {

--- a/cmd/horde/main_test.go
+++ b/cmd/horde/main_test.go
@@ -90,7 +90,7 @@ func TestLaunch_Success(t *testing.T) {
 	os.Stdout = pw
 	defer func() { os.Stdout = origStdout }()
 
-	err = newApp().Run(ctx, []string{"horde", "--provider", "docker", "launch", "TICKET-1"})
+	err = newApp().Run(ctx, []string{"horde", "--provider", "docker", "launch", "--workflow", "test-flow", "TICKET-1"})
 
 	pw.Close()
 	os.Stdout = origStdout
@@ -259,12 +259,86 @@ func TestLaunch_MissingTicket(t *testing.T) {
 	_ = setupLaunchEnv(t)
 	ctx := context.Background()
 
-	err := newApp().Run(ctx, []string{"horde", "--provider", "docker", "launch"})
+	err := newApp().Run(ctx, []string{"horde", "--provider", "docker", "launch", "--workflow", "test-flow"})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
 	if !strings.Contains(err.Error(), "missing required argument") {
 		t.Errorf("error %q does not contain %q", err.Error(), "missing required argument")
+	}
+}
+
+// TestLaunch_MissingWorkflow ensures launch refuses to proceed when --workflow
+// is omitted entirely (urfave's Required-flag check). Without this guard,
+// orc would silently apply its own default workflow and write audit files
+// under a path horde wouldn't read, leaving cost data orphaned.
+func TestLaunch_MissingWorkflow(t *testing.T) {
+	env := setupLaunchEnv(t)
+	ctx := context.Background()
+
+	err := newApp().Run(ctx, []string{"horde", "--provider", "docker", "launch", "TICKET-1"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "workflow") {
+		t.Errorf("error %q should mention workflow", err.Error())
+	}
+	assertNoRunsRecorded(t, env)
+}
+
+// TestLaunch_EmptyWorkflow ensures whitespace-only --workflow values are
+// rejected before any side effects (DB row, container, image build).
+func TestLaunch_EmptyWorkflow(t *testing.T) {
+	env := setupLaunchEnv(t)
+	ctx := context.Background()
+
+	err := newApp().Run(ctx, []string{"horde", "--provider", "docker", "launch", "--workflow", "   ", "TICKET-1"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "--workflow is required") {
+		t.Errorf("error %q does not contain %q", err.Error(), "--workflow is required")
+	}
+	assertNoRunsRecorded(t, env)
+}
+
+// TestLaunch_InvalidWorkflow ensures path-unsafe workflow values are rejected.
+// Mirrors the validation in provider.DockerProvider.Hydrate; prevents
+// audit-tree paths like audit/../escape/<ticket>/.
+func TestLaunch_InvalidWorkflow(t *testing.T) {
+	env := setupLaunchEnv(t)
+	ctx := context.Background()
+
+	for _, bad := range []string{"../escape", "a/b", `a\b`} {
+		err := newApp().Run(ctx, []string{"horde", "--provider", "docker", "launch", "--workflow", bad, "TICKET-1"})
+		if err == nil {
+			t.Fatalf("workflow %q: expected error, got nil", bad)
+		}
+		if !strings.Contains(err.Error(), "invalid") {
+			t.Errorf("workflow %q: error %q should mention invalid", bad, err.Error())
+		}
+	}
+	assertNoRunsRecorded(t, env)
+}
+
+func assertNoRunsRecorded(t *testing.T, env launchEnv) {
+	t.Helper()
+	dbPath := filepath.Join(filepath.Dir(env.projectDir), ".horde", "horde.db")
+	// DB may not even exist if validation fired before initProviderAndStore.
+	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
+		return
+	}
+	st, err := store.NewSQLiteStore(dbPath)
+	if err != nil {
+		t.Fatalf("opening store: %v", err)
+	}
+	defer st.Close()
+	runs, err := st.ListByRepo(context.Background(), "github.com/test/repo.git", true)
+	if err != nil {
+		t.Fatalf("listing runs: %v", err)
+	}
+	if len(runs) != 0 {
+		t.Errorf("expected no runs recorded, got %d", len(runs))
 	}
 }
 
@@ -283,7 +357,7 @@ func TestLaunch_NotGitRepo(t *testing.T) {
 	t.Cleanup(func() { os.Chdir(oldDir) })
 
 	ctx := context.Background()
-	err := newApp().Run(ctx, []string{"horde", "--provider", "docker", "launch", "TICKET-1"})
+	err := newApp().Run(ctx, []string{"horde", "--provider", "docker", "launch", "--workflow", "test-flow", "TICKET-1"})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -319,7 +393,7 @@ func TestLaunch_MissingEnvFile(t *testing.T) {
 	t.Cleanup(func() { os.Chdir(oldDir) })
 
 	ctx := context.Background()
-	err := newApp().Run(ctx, []string{"horde", "--provider", "docker", "launch", "TICKET-1"})
+	err := newApp().Run(ctx, []string{"horde", "--provider", "docker", "launch", "--workflow", "test-flow", "TICKET-1"})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -356,7 +430,7 @@ func TestLaunch_MissingEnvKey(t *testing.T) {
 	t.Cleanup(func() { os.Chdir(oldDir) })
 
 	ctx := context.Background()
-	err := newApp().Run(ctx, []string{"horde", "--provider", "docker", "launch", "TICKET-1"})
+	err := newApp().Run(ctx, []string{"horde", "--provider", "docker", "launch", "--workflow", "test-flow", "TICKET-1"})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -390,7 +464,7 @@ func TestLaunch_DuplicateTicket_NoForce(t *testing.T) {
 	}
 	st.Close()
 
-	err = newApp().Run(ctx, []string{"horde", "--provider", "docker", "launch", "TICKET-1"})
+	err = newApp().Run(ctx, []string{"horde", "--provider", "docker", "launch", "--workflow", "test-flow", "TICKET-1"})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -446,7 +520,7 @@ func TestLaunch_DuplicateTicket_WithForce(t *testing.T) {
 	os.Stdout = pw
 	defer func() { os.Stdout = origStdout }()
 
-	err = newApp().Run(ctx, []string{"horde", "--provider", "docker", "launch", "--force", "TICKET-1"})
+	err = newApp().Run(ctx, []string{"horde", "--provider", "docker", "launch", "--workflow", "test-flow", "--force", "TICKET-1"})
 
 	pw.Close()
 	os.Stdout = origStdout
@@ -512,7 +586,7 @@ func TestLaunch_MaxConcurrent_Rejected(t *testing.T) {
 	}
 	st.Close()
 
-	err = newApp().Run(ctx, []string{"horde", "--provider", "docker", "launch", "TICKET-NEW"})
+	err = newApp().Run(ctx, []string{"horde", "--provider", "docker", "launch", "--workflow", "test-flow", "TICKET-NEW"})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -527,7 +601,7 @@ func TestLaunch_DockerFailure(t *testing.T) {
 
 	os.WriteFile(filepath.Join(env.binDir, "docker"), []byte("#!/bin/sh\ncase \"$1\" in\n  image) echo \"2099-01-01T00:00:00Z\";;\n  tag) exit 0;;\n  *) echo \"Error: Cannot connect to the Docker daemon\" >&2; exit 1;;\nesac\n"), 0o755)
 
-	err := newApp().Run(ctx, []string{"horde", "--provider", "docker", "launch", "TICKET-1"})
+	err := newApp().Run(ctx, []string{"horde", "--provider", "docker", "launch", "--workflow", "test-flow", "TICKET-1"})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -571,7 +645,7 @@ func TestLaunch_DockerFailure_NoStderrWarning(t *testing.T) {
 	os.Stderr = stderrW
 	defer func() { os.Stderr = origStderr }()
 
-	runErr := newApp().Run(ctx, []string{"horde", "--provider", "docker", "launch", "TICKET-1"})
+	runErr := newApp().Run(ctx, []string{"horde", "--provider", "docker", "launch", "--workflow", "test-flow", "TICKET-1"})
 
 	stderrW.Close()
 	os.Stderr = origStderr
@@ -613,7 +687,7 @@ func TestProvider_InvalidValue(t *testing.T) {
 	_ = setupLaunchEnv(t)
 	ctx := context.Background()
 
-	err := newApp().Run(ctx, []string{"horde", "--provider", "gcp", "launch", "TICKET-1"})
+	err := newApp().Run(ctx, []string{"horde", "--provider", "gcp", "launch", "--workflow", "test-flow", "TICKET-1"})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -634,7 +708,7 @@ func TestProvider_ExplicitDocker(t *testing.T) {
 	os.Stdout = pw
 	defer func() { os.Stdout = origStdout }()
 
-	err = newApp().Run(ctx, []string{"horde", "--provider", "docker", "launch", "TICKET-1"})
+	err = newApp().Run(ctx, []string{"horde", "--provider", "docker", "launch", "--workflow", "test-flow", "TICKET-1"})
 
 	pw.Close()
 	os.Stdout = origStdout
@@ -682,7 +756,7 @@ func TestProfile_AcceptedAsGlobalFlag(t *testing.T) {
 	os.Stdout = pw
 	defer func() { os.Stdout = origStdout }()
 
-	err = newApp().Run(ctx, []string{"horde", "--provider", "docker", "--profile", "staging", "launch", "TICKET-1"})
+	err = newApp().Run(ctx, []string{"horde", "--provider", "docker", "--profile", "staging", "launch", "--workflow", "test-flow", "TICKET-1"})
 
 	pw.Close()
 	os.Stdout = origStdout
@@ -1526,6 +1600,80 @@ esac
 	if run.TotalCostUSD == nil || *run.TotalCostUSD != 7.50 {
 		t.Errorf("store TotalCostUSD = %v, want 7.50", run.TotalCostUSD)
 	}
+}
+
+// TestPrintRunStatus_NilCost verifies that `horde status` prints a
+// "Cost:        -" line when TotalCostUSD is nil — matches the list
+// table's behavior so users see a consistent placeholder rather than a
+// silently missing field.
+func TestPrintRunStatus_NilCost(t *testing.T) {
+	run := &store.Run{
+		ID:         "abcdef123456",
+		Repo:       "github.com/test/repo.git",
+		Ticket:     "TICKET-1",
+		Workflow:   "test-flow",
+		Provider:   "docker",
+		Status:     store.StatusFailed,
+		LaunchedBy: "testuser",
+		StartedAt:  time.Now().Add(-1 * time.Minute),
+		// TotalCostUSD intentionally nil
+	}
+	now := time.Now()
+	run.CompletedAt = &now
+
+	stdout := captureStdout(t, func() { printRunStatus(run) })
+
+	if !strings.Contains(stdout, "Cost:        -") {
+		t.Errorf("stdout should contain 'Cost:        -' line; got:\n%s", stdout)
+	}
+}
+
+// TestPrintRunStatus_WithCost is the positive control for
+// TestPrintRunStatus_NilCost.
+func TestPrintRunStatus_WithCost(t *testing.T) {
+	cost := 1.23
+	run := &store.Run{
+		ID:           "abcdef123456",
+		Repo:         "github.com/test/repo.git",
+		Ticket:       "TICKET-1",
+		Workflow:     "test-flow",
+		Provider:     "docker",
+		Status:       store.StatusSuccess,
+		LaunchedBy:   "testuser",
+		StartedAt:    time.Now().Add(-1 * time.Minute),
+		TotalCostUSD: &cost,
+	}
+	now := time.Now()
+	run.CompletedAt = &now
+
+	stdout := captureStdout(t, func() { printRunStatus(run) })
+
+	if !strings.Contains(stdout, "Cost:        $1.23") {
+		t.Errorf("stdout should contain 'Cost:        $1.23'; got:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "Cost:        -") {
+		t.Errorf("stdout should NOT contain 'Cost:        -' when cost is set; got:\n%s", stdout)
+	}
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	origStdout := os.Stdout
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("creating pipe: %v", err)
+	}
+	os.Stdout = pw
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		io.Copy(&buf, pr)
+		done <- buf.String()
+	}()
+	fn()
+	pw.Close()
+	os.Stdout = origStdout
+	return <-done
 }
 
 // --- List tests ---

--- a/internal/docs/content.go
+++ b/internal/docs/content.go
@@ -83,7 +83,9 @@ const topicQuickstart = `Quick Start
 
 3. Launch a run:
 
-    horde launch PROJ-123
+    horde launch --workflow implement-ticket PROJ-123
+
+   --workflow is required and selects an orc workflow from .orc/workflows/.
 
    On the first launch, horde builds the worker Docker image automatically.
    This takes a few minutes. Subsequent launches reuse the cached image
@@ -242,8 +244,8 @@ Docker Provider (v0.1)
 
 The Docker provider runs horde-worker:latest locally via 'docker run'.
 
-    horde launch PROJ-123                   # uses docker by default
-    horde launch PROJ-123 --provider docker # explicit
+    horde launch --workflow implement-ticket PROJ-123                    # uses docker by default
+    horde launch --workflow implement-ticket PROJ-123 --provider docker  # explicit
 
 How it works:
 
@@ -283,7 +285,7 @@ AWS ECS Provider (planned — v0.2)
 
 The ECS provider will run horde-worker as an ECS Fargate task.
 
-    horde launch PROJ-123 --provider aws-ecs
+    horde launch --workflow implement-ticket PROJ-123 --provider aws-ecs
 
 Planned features:
     - ECS RunTask for launching (no Lambda indirection)
@@ -525,7 +527,7 @@ Workflow
   horde bootstrap init       # generates .horde/cloudformation.yaml
   horde bootstrap deploy     # creates or updates the CloudFormation stack
   horde push                 # tags and pushes horde-worker:latest to ECR
-  horde launch --provider aws-ecs -t TICKET-123
+  horde launch --provider aws-ecs --workflow implement-ticket TICKET-123
   horde bootstrap destroy    # tears everything down
 
 Step 1 — horde bootstrap init

--- a/test/integration/launch_test.go
+++ b/test/integration/launch_test.go
@@ -16,7 +16,7 @@ func TestLaunchMissingTicket(t *testing.T) {
 	}
 
 	h := newHarness(t)
-	_, stderr, err := h.runHordeFull("--provider", "docker", "launch")
+	_, stderr, err := h.runHordeFull("--provider", "docker", "launch", "--workflow", "test-flow")
 	if err == nil {
 		t.Fatal("expected error for missing ticket, got nil")
 	}
@@ -34,7 +34,7 @@ func TestLaunchMissingEnvFile(t *testing.T) {
 	h := newHarness(t)
 	os.Remove(filepath.Join(h.workDir, ".env"))
 
-	_, stderr, err := h.runHordeFull("--provider", "docker", "launch", "TEST-no-env")
+	_, stderr, err := h.runHordeFull("--provider", "docker", "launch", "--workflow", "test-flow", "TEST-no-env")
 	if err == nil {
 		t.Fatal("expected error for missing .env, got nil")
 	}
@@ -58,7 +58,7 @@ func TestLaunchNotGitRepo(t *testing.T) {
 		[]byte("CLAUDE_CODE_OAUTH_TOKEN=x\nGIT_TOKEN=x\n"), 0o644)
 	h.workDir = nonGitDir
 
-	_, stderr, err := h.runHordeFull("--provider", "docker", "launch", "TEST-no-git")
+	_, stderr, err := h.runHordeFull("--provider", "docker", "launch", "--workflow", "test-flow", "TEST-no-git")
 	if err == nil {
 		t.Fatal("expected error for non-git directory, got nil")
 	}


### PR DESCRIPTION
## Summary

`horde list` was showing `-` in the COST column for every successful run on
the kitchen-scheduler project even though the runs completed and opened PRs.
Root cause: `horde launch <ticket>` without `--workflow` stored
`run.Workflow = ""`, the entrypoint ran `orc run <ticket>` with no `-w`,
orc applied its own default workflow (`implement-ticket`) and wrote
`audit/implement-ticket/<ticket>/run-result.json`, and horde's `Finalize`
looked at `audit/<ticket>/run-result.json`. The read silently failed and
`run.TotalCostUSD` stayed `nil`. The same root cause hid the cost line in
`horde status`.

Fix: require `--workflow` at launch and reject the call before any side
effects (urfave's `Required: true` + trim/path-safety checks). Also print
`Cost:        -` in `horde status` when cost is nil, matching the table.

Updates SPEC.md, ORC_CONTRACT_EXPECTATIONS.md, README.md, and the
`internal/docs` help text to remove all references to a horde-side default
workflow and to make clear horde always passes `-w <workflow>` to orc.

Per direction, no backfill of existing terminal rows with `NULL` cost —
fix forward only.

## Test Plan

- [x] `make build`, `make vet`
- [x] `make unit-test` — all packages pass; new tests cover missing flag,
      whitespace-only value, path-unsafe values, and the `Cost: -` line
- [x] `make integration-test` — passes (393s, real Docker)
- [x] Manual: `horde launch SOME-TICKET` (no flag) → urfave required-flag error
- [x] Manual: `horde launch --workflow ../bad SOME-TICKET` → `--workflow "../bad" is invalid` error
- [x] Manual: `horde launch --workflow implement-ticket SOME-TICKET` → proceeds normally

## Notes

- Existing tests that drove the launch CLI without `--workflow` were
  updated to pass `--workflow test-flow`. Tests that construct `Run`
  records with `Workflow: ""` directly (read-path tests against legacy
  rows) were left alone.
- The `WORKFLOW`-empty branch in `docker/entrypoint.sh` is now unreachable
  but kept as a defensive belt-and-suspenders.