### PR TITLE
ship @horde.io/cdk@0.2.0: task-role IAM fix + tag-driven npm publish

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,8 @@
 # Run `claude setup-token` to generate the OAuth token.
 CLAUDE_CODE_OAUTH_TOKEN=
 GIT_TOKEN=
+
+# Need additional secrets in the worker container? Declare them in
+# .horde/config.yaml under the `secrets:` block (host env-var names go
+# here in .env, container env-var names live in config.yaml). See
+# `horde docs config` for the full schema.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,39 @@
+name: publish-cdk
+
+# Publish @horde.io/cdk on every v-prefix tag. Auth is npm trusted-publisher
+# OIDC — no NODE_AUTH_TOKEN, no secrets in the repo. One-time setup at
+# https://www.npmjs.com/package/@horde.io/cdk/access must link this repo +
+# workflow + job before the first tag is cut.
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish-cdk:
+    name: publish-cdk
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    defaults:
+      run:
+        working-directory: cdk
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+          cache: npm
+          cache-dependency-path: cdk/package-lock.json
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - run: npm test
+
+      - run: npm publish --provenance --access public

--- a/.horde/config.yaml
+++ b/.horde/config.yaml
@@ -1,4 +1,28 @@
 # Project-level horde configuration.
+# Full schema: `horde docs config`.
+
 # Volume mounts in host:container format (host side relative to project root).
 mounts:
   - .beads:/workspace/.beads
+
+# Caller-declared env-var secrets injected into the worker container.
+# The two canonicals (CLAUDE_CODE_OAUTH_TOKEN, GIT_TOKEN) are auto-seeded
+# with their default sources — declare them here only to override.
+#
+# Each entry can list per-provider sources; the active provider picks
+# the matching one. v0.2 supports two source kinds:
+#
+#   env: <NAME>          host env-var name (read from .env on docker)
+#   aws-secret: <NAME>   AWS Secrets Manager secret name (ECS) — caller
+#                        is responsible for creating the secret before
+#                        running `horde bootstrap deploy`
+#
+# Uncomment to add additional secrets:
+#
+# secrets:
+#   REVIEW_GIT_TOKEN:
+#     env: REVIEW_GIT_TOKEN
+#     aws-secret: horde/review-git-token
+#   STRIPE_API_KEY:
+#     env: STRIPE_API_KEY
+#     aws-secret: prepdesk/stripe-api-key

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ target (or `cd cdk && npm ci && npm run build && npm test` for cdk-test).
 ## Key Design Decisions
 
 - Git is a hard requirement — repo URL inferred from local git remote
-- Optional project config in `.horde/config.yaml` (volume mounts); secrets from `.env` file (gitignored) via `docker run --env-file`
+- Optional project config in `.horde/config.yaml` (volume mounts; `secrets:` block declares extra env-var secrets beyond the two canonical `CLAUDE_CODE_OAUTH_TOKEN`/`GIT_TOKEN` — see `horde docs config`); secrets from `.env` file (gitignored) via `docker run --env-file`
 - GIT_TOKEN protected via `GIT_ASKPASS` credential helper — never in process args or `.git/config`
 - SQLite for local run history (`~/.horde/horde.db`); DynamoDB for shared team history (v0.2)
 - Store selection follows provider: docker → SQLite, aws-ecs → DynamoDB

--- a/README.md
+++ b/README.md
@@ -40,6 +40,22 @@ Edit `.env` and fill in:
 
 Run `horde docs env` for more detail on token setup and security.
 
+### Additional secrets
+
+Projects can declare extra environment-variable secrets in `.horde/config.yaml`:
+
+```yaml
+secrets:
+  REVIEW_GIT_TOKEN:
+    env: REVIEW_GIT_TOKEN              # docker: read from .env
+    aws-secret: horde/review-git-token # ecs: name of pre-existing Secrets Manager entry
+  STRIPE_API_KEY:
+    env: STRIPE_API_KEY
+    aws-secret: prepdesk/stripe-api-key
+```
+
+Each entry's per-provider source is picked at launch time. The two canonical secrets (`CLAUDE_CODE_OAUTH_TOKEN`, `GIT_TOKEN`) are auto-seeded; declare them only to override. ECS extras must already exist in Secrets Manager — `horde bootstrap init`/`deploy` wires the IAM grants and task-definition references but does not create the secrets themselves. Full schema: `horde docs config`.
+
 ## Quickstart: AWS (v0.2)
 
 Stand up the cloud backend once, then every `horde launch` from the project runs on ECS Fargate. Two provisioning paths — pick one.

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@horde.io/cdk",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "AWS CDK construct that provisions the infrastructure required by horde (https://github.com/jorge-barreto/horde): ECS Fargate cluster, DynamoDB runs table, S3 artifacts bucket, SSM config parameter, EventBridge status sync, and scoped IAM.",
   "license": "MIT",
   "main": "lib/index.js",

--- a/cdk/src/horde-worker-props.ts
+++ b/cdk/src/horde-worker-props.ts
@@ -8,12 +8,22 @@ import type { ISecret } from "aws-cdk-lib/aws-secretsmanager";
  * Secrets injected into the worker container at runtime via ECS Secrets
  * Manager `valueFrom` (resolved by the task execution role at container start
  * — never via plain env vars).
+ *
+ * The two canonical entries (`CLAUDE_CODE_OAUTH_TOKEN`, `GIT_TOKEN`) are
+ * required and match the keys baked into the bootstrap CloudFormation
+ * template. Extra entries are added via the index signature — each becomes
+ * an additional task-definition `secrets:` entry with an IAM grant on
+ * both the task role and the execution role. Caller must reference an
+ * existing Secrets Manager secret (typically via
+ * `secretsmanager.Secret.fromSecretNameV2(...)`).
  */
 export interface HordeWorkerSecrets {
   /** Claude Code OAuth token. Becomes env `CLAUDE_CODE_OAUTH_TOKEN`. */
   readonly CLAUDE_CODE_OAUTH_TOKEN: ISecret;
   /** Git provider token (e.g. GitHub PAT). Becomes env `GIT_TOKEN`. */
   readonly GIT_TOKEN: ISecret;
+  /** Additional caller-declared secrets — env-var name → ISecret. */
+  readonly [envVarName: string]: ISecret;
 }
 
 /**

--- a/cdk/src/horde-worker.ts
+++ b/cdk/src/horde-worker.ts
@@ -265,14 +265,27 @@ export class HordeWorker extends Construct {
       projectionType: dynamodb.ProjectionType.ALL,
     });
 
-    // Task role: write-only access to its own artifact prefix.
-    // Reading happens via the CLI (with the cli-user managed policy).
+    // Task role: read+write on its own artifact prefix, plus ListBucket on
+    // the bucket. Read+List are needed because the worker entrypoint runs
+    // `aws s3 sync s3://${ARTIFACTS_BUCKET}/horde-runs/${RUN_ID}/sessions/`
+    // (docker/entrypoint.sh) to restore prior agent session state — the
+    // sync calls ListObjectsV2 (s3:ListBucket) and GetObject. Mirrors the
+    // task-role IAM in internal/bootstrap/templates/stack.yaml.tmpl so the
+    // CDK and CloudFormation onboarding paths stay in lockstep.
     this.taskRole.addToPolicy(
       new iam.PolicyStatement({
         sid: "ArtifactsWrite",
         effect: iam.Effect.ALLOW,
-        actions: ["s3:PutObject", "s3:AbortMultipartUpload"],
+        actions: ["s3:PutObject", "s3:AbortMultipartUpload", "s3:GetObject"],
         resources: [`${this.artifactsBucket.bucketArn}/horde-runs/*`],
+      }),
+    );
+    this.taskRole.addToPolicy(
+      new iam.PolicyStatement({
+        sid: "ArtifactsList",
+        effect: iam.Effect.ALLOW,
+        actions: ["s3:ListBucket"],
+        resources: [this.artifactsBucket.bucketArn],
       }),
     );
 

--- a/cdk/src/horde-worker.ts
+++ b/cdk/src/horde-worker.ts
@@ -276,6 +276,22 @@ export class HordeWorker extends Construct {
       }),
     );
 
+    // Wire every entry in props.secrets through ecs.Secret.fromSecretsManager
+    // so the canonical pair plus any caller-declared extras flow into the
+    // task definition's secrets array. Each ISecret must already exist or
+    // be created by the caller; the construct does not create the
+    // Secrets Manager entries itself.
+    const taskDefSecrets: { [k: string]: ecs.Secret } = {};
+    for (const envName of Object.keys(props.secrets)) {
+      const isecret = props.secrets[envName];
+      if (!isecret) {
+        throw new Error(
+          `HordeWorker: secrets["${envName}"] is undefined. ` +
+            `Every entry must reference a SecretsManager ISecret.`,
+        );
+      }
+      taskDefSecrets[envName] = ecs.Secret.fromSecretsManager(isecret);
+    }
     this.container = this.taskDefinition.addContainer("worker", {
       containerName: "horde-worker",
       image: props.workerImage,
@@ -285,12 +301,7 @@ export class HordeWorker extends Construct {
         logGroup: this.logGroup,
         streamPrefix: "ecs",
       }),
-      secrets: {
-        CLAUDE_CODE_OAUTH_TOKEN: ecs.Secret.fromSecretsManager(
-          props.secrets.CLAUDE_CODE_OAUTH_TOKEN,
-        ),
-        GIT_TOKEN: ecs.Secret.fromSecretsManager(props.secrets.GIT_TOKEN),
-      },
+      secrets: taskDefSecrets,
     });
 
     // SSM config parameter consumed by the horde CLI. JSON keys must match

--- a/cdk/test/__snapshots__/horde-worker-matrix.test.ts.snap
+++ b/cdk/test/__snapshots__/horde-worker-matrix.test.ts.snap
@@ -1104,6 +1104,7 @@ exports[`HordeWorker matrix — default (no vpc, no bucket) matches the saved sn
               "Action": [
                 "s3:PutObject",
                 "s3:AbortMultipartUpload",
+                "s3:GetObject",
               ],
               "Effect": "Allow",
               "Resource": {
@@ -1121,6 +1122,17 @@ exports[`HordeWorker matrix — default (no vpc, no bucket) matches the saved sn
                 ],
               },
               "Sid": "ArtifactsWrite",
+            },
+            {
+              "Action": "s3:ListBucket",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "HordeArtifactsBucket1A7FD4A4",
+                  "Arn",
+                ],
+              },
+              "Sid": "ArtifactsList",
             },
           ],
           "Version": "2012-10-17",
@@ -2416,6 +2428,7 @@ exports[`HordeWorker matrix — provided bucket matches the saved snapshot 1`] =
               "Action": [
                 "s3:PutObject",
                 "s3:AbortMultipartUpload",
+                "s3:GetObject",
               ],
               "Effect": "Allow",
               "Resource": {
@@ -2433,6 +2446,17 @@ exports[`HordeWorker matrix — provided bucket matches the saved snapshot 1`] =
                 ],
               },
               "Sid": "ArtifactsWrite",
+            },
+            {
+              "Action": "s3:ListBucket",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "ProvidedBucket8A3897F1",
+                  "Arn",
+                ],
+              },
+              "Sid": "ArtifactsList",
             },
           ],
           "Version": "2012-10-17",
@@ -3736,6 +3760,7 @@ exports[`HordeWorker matrix — provided vpc and bucket matches the saved snapsh
               "Action": [
                 "s3:PutObject",
                 "s3:AbortMultipartUpload",
+                "s3:GetObject",
               ],
               "Effect": "Allow",
               "Resource": {
@@ -3753,6 +3778,17 @@ exports[`HordeWorker matrix — provided vpc and bucket matches the saved snapsh
                 ],
               },
               "Sid": "ArtifactsWrite",
+            },
+            {
+              "Action": "s3:ListBucket",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "ProvidedBucket8A3897F1",
+                  "Arn",
+                ],
+              },
+              "Sid": "ArtifactsList",
             },
           ],
           "Version": "2012-10-17",
@@ -5260,6 +5296,7 @@ exports[`HordeWorker matrix — provided vpc matches the saved snapshot 1`] = `
               "Action": [
                 "s3:PutObject",
                 "s3:AbortMultipartUpload",
+                "s3:GetObject",
               ],
               "Effect": "Allow",
               "Resource": {
@@ -5277,6 +5314,17 @@ exports[`HordeWorker matrix — provided vpc matches the saved snapshot 1`] = `
                 ],
               },
               "Sid": "ArtifactsWrite",
+            },
+            {
+              "Action": "s3:ListBucket",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "HordeArtifactsBucket1A7FD4A4",
+                  "Arn",
+                ],
+              },
+              "Sid": "ArtifactsList",
             },
           ],
           "Version": "2012-10-17",

--- a/cdk/test/__snapshots__/horde-worker.test.ts.snap
+++ b/cdk/test/__snapshots__/horde-worker.test.ts.snap
@@ -1104,6 +1104,7 @@ exports[`HordeWorker (5fh.3 skeleton) matches the saved snapshot 1`] = `
               "Action": [
                 "s3:PutObject",
                 "s3:AbortMultipartUpload",
+                "s3:GetObject",
               ],
               "Effect": "Allow",
               "Resource": {
@@ -1121,6 +1122,17 @@ exports[`HordeWorker (5fh.3 skeleton) matches the saved snapshot 1`] = `
                 ],
               },
               "Sid": "ArtifactsWrite",
+            },
+            {
+              "Action": "s3:ListBucket",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "HordeArtifactsBucket1A7FD4A4",
+                  "Arn",
+                ],
+              },
+              "Sid": "ArtifactsList",
             },
           ],
           "Version": "2012-10-17",

--- a/cdk/test/horde-worker.test.ts
+++ b/cdk/test/horde-worker.test.ts
@@ -125,7 +125,7 @@ describe("HordeWorker (5fh.3 skeleton)", () => {
     });
   });
 
-  it("scopes the task role to PutObject/AbortMultipartUpload on horde-runs/* only", () => {
+  it("grants the task role read+write on horde-runs/* and ListBucket on the bucket", () => {
     const t = synth();
     t.hasResourceProperties("AWS::IAM::Policy", {
       PolicyDocument: Match.objectLike({
@@ -133,12 +133,22 @@ describe("HordeWorker (5fh.3 skeleton)", () => {
           Match.objectLike({
             Sid: "ArtifactsWrite",
             Effect: "Allow",
-            Action: ["s3:PutObject", "s3:AbortMultipartUpload"],
+            Action: Match.arrayWith([
+              "s3:PutObject",
+              "s3:AbortMultipartUpload",
+              "s3:GetObject",
+            ]),
             Resource: Match.objectLike({
               "Fn::Join": Match.arrayWith([
                 Match.arrayWith([Match.stringLikeRegexp(".*horde-runs/\\*")]),
               ]),
             }),
+          }),
+          Match.objectLike({
+            Sid: "ArtifactsList",
+            Effect: "Allow",
+            Action: "s3:ListBucket",
+            Resource: { "Fn::GetAtt": Match.arrayWith([Match.stringLikeRegexp("ArtifactsBucket.*"), "Arn"]) },
           }),
         ]),
       }),

--- a/cdk/test/horde-worker.test.ts
+++ b/cdk/test/horde-worker.test.ts
@@ -500,6 +500,39 @@ describe("HordeWorker status-sync (5fh.12/13/14)", () => {
     }
   });
 
+  it("includes caller-declared extra secrets in the task-def secrets array", () => {
+    const app = new App();
+    const stack = new Stack(app, "TestStackExtras", {
+      env: { account: "111111111111", region: "us-east-1" },
+    });
+    const repo = ecr.Repository.fromRepositoryName(stack, "Repo", "horde-test");
+    new HordeWorker(stack, "Horde", {
+      projectSlug: "test",
+      workerImage: ecs.ContainerImage.fromRegistry("public.ecr.aws/horde/test:latest"),
+      ecrRepository: repo,
+      secrets: {
+        CLAUDE_CODE_OAUTH_TOKEN: secretsmanager.Secret.fromSecretNameV2(stack, "Claude", "horde/claude"),
+        GIT_TOKEN: secretsmanager.Secret.fromSecretNameV2(stack, "Git", "horde/git"),
+        REVIEW_GIT_TOKEN: secretsmanager.Secret.fromSecretNameV2(stack, "Review", "horde/review-git-token"),
+        STRIPE_API_KEY: secretsmanager.Secret.fromSecretNameV2(stack, "Stripe", "prepdesk/stripe-api-key"),
+      },
+    });
+    const t = Template.fromStack(stack);
+    t.hasResourceProperties("AWS::ECS::TaskDefinition", {
+      ContainerDefinitions: Match.arrayWith([
+        Match.objectLike({
+          Name: "horde-worker",
+          Secrets: Match.arrayWith([
+            Match.objectLike({ Name: "CLAUDE_CODE_OAUTH_TOKEN" }),
+            Match.objectLike({ Name: "GIT_TOKEN" }),
+            Match.objectLike({ Name: "REVIEW_GIT_TOKEN" }),
+            Match.objectLike({ Name: "STRIPE_API_KEY" }),
+          ]),
+        }),
+      ]),
+    });
+  });
+
   it("does NOT grant the status lambda ecs/ssm/secrets permissions", () => {
     const t = synth();
     const policies = t.findResources("AWS::IAM::Policy");

--- a/cmd/horde/bootstrap.go
+++ b/cmd/horde/bootstrap.go
@@ -79,7 +79,12 @@ func bootstrapInitCmd() *cli.Command {
 				}
 			}
 
-			rendered, err := bootstrap.Render(slug)
+			projCfg, err := config.LoadProjectConfig(cwd)
+			if err != nil {
+				return err
+			}
+			merged := config.MergeSecrets(projCfg.Secrets)
+			rendered, err := bootstrap.Render(slug, merged.ExtraAWSSecretNames())
 			if err != nil {
 				return err
 			}

--- a/cmd/horde/main.go
+++ b/cmd/horde/main.go
@@ -113,10 +113,11 @@ func launchCmd() *cli.Command {
 		Name:      "launch",
 		Usage:     "Launch an orc workflow",
 		ArgsUsage: "<ticket> [-- <orc-args>...]",
-		Description: `Builds the worker Docker image if needed, validates the .env file,
-and launches a container that clones the repo and runs orc. Prints the
-run ID on success. Use --force to launch even if a run with the same
-ticket is already active.
+		Description: `Builds the worker Docker image if needed, validates the .env file
+(every secret declared in .horde/config.yaml's secrets: block plus the
+two canonical defaults), and launches a container that clones the repo
+and runs orc. Prints the run ID on success. Use --force to launch even
+if a run with the same ticket is already active.
 
 Concurrency: docker provider caps active runs at 100 (pending + running);
 aws-ecs uses the bootstrap stack's max_concurrent (default 20). Hitting
@@ -199,12 +200,9 @@ kill some runs before launching more.`,
 				return err
 			}
 
-			var envPath string
-			if provName == "docker" {
-				envPath, err = config.ValidateEnvFile(cwd)
-				if err != nil {
-					return err
-				}
+			envPath, _, secretRemap, err := resolveSecretsForLaunch(provName, cwd)
+			if err != nil {
+				return err
 			}
 
 			id, err := runid.Generate()
@@ -278,15 +276,16 @@ kill some runs before launching more.`,
 			}
 
 			result, err := prov.Launch(ctx, provider.LaunchOpts{
-				Repo:     repo,
-				Ticket:   ticket,
-				Branch:   branch,
-				Workflow: workflow,
-				RunID:    id,
-				EnvFile:  envPath,
-				Mounts:   projCfg.ResolveMounts(cwd),
-				HomeDir:  homeDir,
-				OrcArgs:  orcArgs,
+				Repo:           repo,
+				Ticket:         ticket,
+				Branch:         branch,
+				Workflow:       workflow,
+				RunID:          id,
+				EnvFile:        envPath,
+				Mounts:         projCfg.ResolveMounts(cwd),
+				HomeDir:        homeDir,
+				OrcArgs:        orcArgs,
+				SecretEnvRemap: secretRemap,
 			})
 			if err != nil {
 				failedStatus := store.StatusFailed
@@ -390,12 +389,9 @@ resumes any interrupted agent session. Override with explicit orc args:
 			if err != nil {
 				return fmt.Errorf("getting working directory: %w", err)
 			}
-			var envPath string
-			if run.Provider == "docker" {
-				envPath, err = config.ValidateEnvFile(cwd)
-				if err != nil {
-					return err
-				}
+			envPath, _, secretRemap, err := resolveSecretsForLaunch(run.Provider, cwd)
+			if err != nil {
+				return err
 			}
 			projCfg, err := config.LoadProjectConfig(cwd)
 			if err != nil {
@@ -416,15 +412,16 @@ resumes any interrupted agent session. Override with explicit orc args:
 			os.Remove(filepath.Join(workspaceDir, ".horde-exit-code"))
 
 			result, err := prov.Launch(ctx, provider.LaunchOpts{
-				Repo:     run.Repo,
-				Ticket:   run.Ticket,
-				Branch:   run.Branch,
-				Workflow: run.Workflow,
-				RunID:    run.ID,
-				EnvFile:  envPath,
-				Mounts:   projCfg.ResolveMounts(cwd),
-				HomeDir:  homeDir,
-				OrcArgs:  orcArgs,
+				Repo:           run.Repo,
+				Ticket:         run.Ticket,
+				Branch:         run.Branch,
+				Workflow:       run.Workflow,
+				RunID:          run.ID,
+				EnvFile:        envPath,
+				Mounts:         projCfg.ResolveMounts(cwd),
+				HomeDir:        homeDir,
+				OrcArgs:        orcArgs,
+				SecretEnvRemap: secretRemap,
 			})
 			if err != nil {
 				return fmt.Errorf("relaunching container for retry: %w", err)
@@ -1046,6 +1043,51 @@ type liveCosts struct {
 }
 
 // fetchLiveCost reads the current cost from a running container's costs.json.
+// resolveSecretsForLaunch loads .horde/config.yaml, merges in the canonical
+// secret defaults, and validates the result against the active provider.
+// For docker it also verifies dir/.env covers every host env-var name the
+// spec references. Returns the (possibly empty) envPath, the merged spec,
+// and a non-canonical "container-name -> host-env-name" remap for the
+// docker provider; the ECS provider gets nil remap (its task definition
+// is baked at bootstrap time).
+func resolveSecretsForLaunch(provName, dir string) (envPath string, spec config.SecretSpec, remap map[string]string, err error) {
+	cfg, err := config.LoadProjectConfig(dir)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	spec = config.MergeSecrets(cfg.Secrets)
+	if err := spec.ValidateForProvider(provName); err != nil {
+		return "", nil, nil, err
+	}
+	if provName == config.ProviderDocker {
+		envPath, err = config.ValidateEnvFileFor(dir, spec)
+		if err != nil {
+			return "", nil, nil, err
+		}
+		remap = map[string]string{}
+		for containerName, src := range spec {
+			if src.Env == "" {
+				continue
+			}
+			// Canonicals are covered by --env-file (their container-name
+			// matches the host-name verbatim by definition). Skip identity
+			// mappings to keep argv minimal.
+			if config.IsCanonical(containerName) && src.Env == containerName {
+				continue
+			}
+			if src.Env == containerName {
+				continue
+			}
+			remap[containerName] = src.Env
+		}
+		// For non-canonical entries whose container-name matches
+		// host-name, --env-file already publishes them under the right
+		// name (since .env contains them and docker forwards everything
+		// in the file). No extra -e needed in that case either.
+	}
+	return envPath, spec, remap, nil
+}
+
 func fetchLiveCost(ctx context.Context, prov *provider.DockerProvider, run *store.Run) *float64 {
 	if run.InstanceID == "" {
 		return nil

--- a/cmd/horde/main_test.go
+++ b/cmd/horde/main_test.go
@@ -434,8 +434,8 @@ func TestLaunch_MissingEnvKey(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
-	if !strings.Contains(err.Error(), "missing required key GIT_TOKEN") {
-		t.Errorf("error %q does not contain %q", err.Error(), "missing required key GIT_TOKEN")
+	if !strings.Contains(err.Error(), "GIT_TOKEN") {
+		t.Errorf("error %q does not name missing key GIT_TOKEN", err.Error())
 	}
 }
 

--- a/examples/cdk-consumer/package.json
+++ b/examples/cdk-consumer/package.json
@@ -10,7 +10,7 @@
     "destroy": "cdk destroy --app 'npx ts-node --prefer-ts-exts app.ts'"
   },
   "dependencies": {
-    "@horde.io/cdk": "^0.1.0",
+    "@horde.io/cdk": "^0.2.0",
     "aws-cdk-lib": "^2.150.0",
     "constructs": "^10.3.0"
   },

--- a/internal/bootstrap/template.go
+++ b/internal/bootstrap/template.go
@@ -6,14 +6,29 @@ import (
 	"fmt"
 	"strings"
 	"text/template"
+
+	"github.com/jorge-barreto/horde/internal/config"
 )
 
 //go:embed templates/stack.yaml.tmpl
 var stackTemplateSource string
 
-// Render generates a CloudFormation stack template for the given project slug.
-// The slug is expected to come from Slug(remoteURL).
-func Render(slug string) ([]byte, error) {
+// Render generates a CloudFormation stack template for the given project
+// slug. The slug is expected to come from Slug(remoteURL).
+//
+// extraSecrets are caller-declared aws-secret references beyond the two
+// canonicals (CLAUDE_CODE_OAUTH_TOKEN, GIT_TOKEN). Each one becomes:
+//
+//   - an extra entry in the worker container's Secrets array (env name =
+//     EnvName, ValueFrom = the looked-up Secrets Manager ARN)
+//   - extra resources in the IAM Allow-Resource lists for both the
+//     execution role's ResolveContainerSecrets and the task role's
+//     SecretsRead policies
+//
+// The caller is responsible for ensuring the named Secrets Manager
+// entries actually exist before deploy. Pass nil/empty for the v0.2
+// canonical-only case (zero migration).
+func Render(slug string, extraSecrets []config.ExtraAWSSecret) ([]byte, error) {
 	if strings.TrimSpace(slug) == "" {
 		return nil, fmt.Errorf("rendering stack template: slug is empty")
 	}
@@ -22,7 +37,14 @@ func Render(slug string) ([]byte, error) {
 		return nil, fmt.Errorf("rendering stack template: parsing: %w", err)
 	}
 	var buf bytes.Buffer
-	if err := tmpl.Execute(&buf, struct{ Slug string }{Slug: slug}); err != nil {
+	data := struct {
+		Slug         string
+		ExtraSecrets []config.ExtraAWSSecret
+	}{
+		Slug:         slug,
+		ExtraSecrets: extraSecrets,
+	}
+	if err := tmpl.Execute(&buf, data); err != nil {
 		return nil, fmt.Errorf("rendering stack template: executing: %w", err)
 	}
 	return buf.Bytes(), nil

--- a/internal/bootstrap/template_test.go
+++ b/internal/bootstrap/template_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jorge-barreto/horde/internal/config"
 	"gopkg.in/yaml.v3"
 )
 
@@ -23,7 +24,7 @@ func TestRender_EmptySlug(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			out, err := Render(tc.in)
+			out, err := Render(tc.in, nil)
 			if err == nil {
 				t.Fatalf("expected error for slug %q, got nil", tc.in)
 			}
@@ -39,7 +40,7 @@ func TestRender_EmptySlug(t *testing.T) {
 
 func TestRender_ValidYAML(t *testing.T) {
 	t.Parallel()
-	out, err := Render("myproj")
+	out, err := Render("myproj", nil)
 	if err != nil {
 		t.Fatalf("Render returned error: %v", err)
 	}
@@ -63,7 +64,7 @@ func TestRender_ValidYAML(t *testing.T) {
 
 func TestRender_ContainsSlug(t *testing.T) {
 	t.Parallel()
-	out, err := Render("myproj")
+	out, err := Render("myproj", nil)
 	if err != nil {
 		t.Fatalf("Render returned error: %v", err)
 	}
@@ -92,7 +93,7 @@ func TestRender_ContainsSlug(t *testing.T) {
 
 func TestRender_ResourcesPresent(t *testing.T) {
 	t.Parallel()
-	out, err := Render("myproj")
+	out, err := Render("myproj", nil)
 	if err != nil {
 		t.Fatalf("Render returned error: %v", err)
 	}
@@ -155,7 +156,7 @@ func TestRender_ResourcesPresent(t *testing.T) {
 
 func TestRender_RunsTableGSIs(t *testing.T) {
 	t.Parallel()
-	out, err := Render("myproj")
+	out, err := Render("myproj", nil)
 	if err != nil {
 		t.Fatalf("Render returned error: %v", err)
 	}
@@ -199,7 +200,7 @@ func TestRender_RunsTableGSIs(t *testing.T) {
 
 func TestRender_OutputsPresent(t *testing.T) {
 	t.Parallel()
-	out, err := Render("myproj")
+	out, err := Render("myproj", nil)
 	if err != nil {
 		t.Fatalf("Render returned error: %v", err)
 	}
@@ -242,7 +243,7 @@ func TestRender_OutputsPresent(t *testing.T) {
 
 func TestRender_ParametersPresent(t *testing.T) {
 	t.Parallel()
-	out, err := Render("myproj")
+	out, err := Render("myproj", nil)
 	if err != nil {
 		t.Fatalf("Render returned error: %v", err)
 	}
@@ -273,7 +274,7 @@ func TestRender_ParametersPresent(t *testing.T) {
 // common secret prefixes never appear in the output.
 func TestRender_NoSecretsLeaked(t *testing.T) {
 	t.Parallel()
-	out, err := Render("myproj")
+	out, err := Render("myproj", nil)
 	if err != nil {
 		t.Fatalf("Render returned error: %v", err)
 	}
@@ -304,7 +305,7 @@ func TestRender_NoSecretsLeaked(t *testing.T) {
 
 func TestRender_TaskDefSecrets(t *testing.T) {
 	t.Parallel()
-	out, err := Render("myproj")
+	out, err := Render("myproj", nil)
 	if err != nil {
 		t.Fatalf("Render returned error: %v", err)
 	}
@@ -360,7 +361,7 @@ func TestRender_TaskDefSecrets(t *testing.T) {
 
 func TestRender_TaskRoleHasPolicies(t *testing.T) {
 	t.Parallel()
-	out, err := Render("myproj")
+	out, err := Render("myproj", nil)
 	if err != nil {
 		t.Fatalf("Render returned error: %v", err)
 	}
@@ -416,7 +417,7 @@ func TestRender_TaskRoleHasPolicies(t *testing.T) {
 
 func TestRender_CliPolicyStatements(t *testing.T) {
 	t.Parallel()
-	out, err := Render("myproj")
+	out, err := Render("myproj", nil)
 	if err != nil {
 		t.Fatalf("Render returned error: %v", err)
 	}
@@ -468,7 +469,7 @@ func TestRender_CliPolicyStatements(t *testing.T) {
 
 func TestRender_SsmConfigParameter(t *testing.T) {
 	t.Parallel()
-	out, err := Render("myproj")
+	out, err := Render("myproj", nil)
 	if err != nil {
 		t.Fatalf("Render returned error: %v", err)
 	}
@@ -489,7 +490,7 @@ func TestRender_SsmConfigParameter(t *testing.T) {
 
 func TestRender_StatusLambdaPython(t *testing.T) {
 	t.Parallel()
-	out, err := Render("myproj")
+	out, err := Render("myproj", nil)
 	if err != nil {
 		t.Fatalf("Render returned error: %v", err)
 	}
@@ -532,13 +533,78 @@ func TestRender_StatusLambdaPython(t *testing.T) {
 	}
 }
 
+func TestRender_ExtraSecrets_TaskDefAndIAM(t *testing.T) {
+	t.Parallel()
+	extras := []config.ExtraAWSSecret{
+		{EnvName: "STRIPE_API_KEY", SecretName: "prepdesk/stripe-api-key"},
+		{EnvName: "REVIEW_GIT_TOKEN", SecretName: "horde/review-git-token"},
+	}
+	out, err := Render("myproj", extras)
+	if err != nil {
+		t.Fatalf("Render returned error: %v", err)
+	}
+	var m map[string]any
+	if err := yaml.Unmarshal(out, &m); err != nil {
+		t.Fatalf("yaml.Unmarshal failed: %v\n%s", err, string(out))
+	}
+	resources := m["Resources"].(map[string]any)
+
+	td := resources["WorkerTaskDefinition"].(map[string]any)
+	props := td["Properties"].(map[string]any)
+	containers := props["ContainerDefinitions"].([]any)
+	container := containers[0].(map[string]any)
+	secrets := container["Secrets"].([]any)
+	if len(secrets) != 4 {
+		t.Fatalf("expected 4 secrets (2 canonical + 2 extra), got %d", len(secrets))
+	}
+	gotEnvNames := map[string]bool{}
+	for _, raw := range secrets {
+		s := raw.(map[string]any)
+		gotEnvNames[s["Name"].(string)] = true
+	}
+	for _, want := range []string{"CLAUDE_CODE_OAUTH_TOKEN", "GIT_TOKEN", "STRIPE_API_KEY", "REVIEW_GIT_TOKEN"} {
+		if !gotEnvNames[want] {
+			t.Errorf("Secrets array missing %q", want)
+		}
+	}
+
+	// IAM grants for both task and execution roles must include each
+	// extra secret name (Fn::Sub'd into a wildcard ARN).
+	rendered := string(out)
+	for _, name := range []string{"prepdesk/stripe-api-key", "horde/review-git-token"} {
+		// Each extra appears twice — once in TaskExecutionRole.Resource,
+		// once in TaskRole.Resource. And again in WorkerTaskDefinition's
+		// Secrets ValueFrom. So we expect at least 3 occurrences.
+		if got := strings.Count(rendered, name); got < 3 {
+			t.Errorf("extra secret %q should appear at least 3 times (2 IAM + 1 task-def), got %d", name, got)
+		}
+	}
+}
+
+func TestRender_NoExtras_NoExtraLines(t *testing.T) {
+	t.Parallel()
+	out, err := Render("myproj", nil)
+	if err != nil {
+		t.Fatalf("Render returned error: %v", err)
+	}
+	s := string(out)
+	// Sanity: stale "ExtraSecrets" identifier should never appear in
+	// output (would mean template var leaked).
+	if strings.Contains(s, "ExtraSecrets") {
+		t.Errorf("rendered template contains stray template identifier ExtraSecrets")
+	}
+	if strings.Contains(s, "{{") {
+		t.Errorf("rendered template contains unsubstituted template directive")
+	}
+}
+
 func TestRender_CfnLint(t *testing.T) {
 	t.Parallel()
 	path, err := exec.LookPath("cfn-lint")
 	if err != nil {
 		t.Skip("cfn-lint not installed")
 	}
-	out, err := Render("myproj")
+	out, err := Render("myproj", nil)
 	if err != nil {
 		t.Fatalf("Render returned error: %v", err)
 	}

--- a/internal/bootstrap/templates/stack.yaml.tmpl
+++ b/internal/bootstrap/templates/stack.yaml.tmpl
@@ -247,6 +247,9 @@ Resources:
                 Resource:
                   - Ref: ClaudeCodeOauthTokenSecret
                   - Ref: GitTokenSecret
+{{- range .ExtraSecrets }}
+                  - Fn::Sub: "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:{{ .SecretName }}-*"
+{{- end }}
       Tags:
         - Key: Name
           Value: "horde-{{.Slug}}-exec-role"
@@ -284,6 +287,9 @@ Resources:
                 Resource:
                   - Ref: ClaudeCodeOauthTokenSecret
                   - Ref: GitTokenSecret
+{{- range .ExtraSecrets }}
+                  - Fn::Sub: "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:{{ .SecretName }}-*"
+{{- end }}
       Tags:
         - Key: Name
           Value: "horde-{{.Slug}}-task-role"
@@ -324,6 +330,11 @@ Resources:
             - Name: GIT_TOKEN
               ValueFrom:
                 Ref: GitTokenSecret
+{{- range .ExtraSecrets }}
+            - Name: {{ .EnvName }}
+              ValueFrom:
+                Fn::Sub: "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:{{ .SecretName }}"
+{{- end }}
           LogConfiguration:
             LogDriver: awslogs
             Options:

--- a/internal/config/envfile.go
+++ b/internal/config/envfile.go
@@ -8,9 +8,21 @@ import (
 	"strings"
 )
 
-// ValidateEnvFile checks that dir/.env exists and contains CLAUDE_CODE_OAUTH_TOKEN and GIT_TOKEN.
-// Returns the absolute path to the .env file on success.
+// ValidateEnvFile checks that dir/.env exists and contains the two
+// canonical secrets (CLAUDE_CODE_OAUTH_TOKEN, GIT_TOKEN). Equivalent to
+// ValidateEnvFileFor(dir, DefaultSecrets()).
+//
+// Prefer ValidateEnvFileFor at call sites that have a merged SecretSpec —
+// it enforces every declared docker source, not only the two canonicals.
 func ValidateEnvFile(dir string) (string, error) {
+	return ValidateEnvFileFor(dir, DefaultSecrets())
+}
+
+// ValidateEnvFileFor checks that dir/.env exists and contains every host
+// env-var name referenced by the spec's docker (Env) sources. Returns the
+// absolute path to the .env file on success. The error names every
+// missing key in one pass so callers don't have to fix .env iteratively.
+func ValidateEnvFileFor(dir string, spec SecretSpec) (string, error) {
 	envPath := filepath.Join(dir, ".env")
 
 	f, err := os.Open(envPath)
@@ -39,11 +51,14 @@ func ValidateEnvFile(dir string) (string, error) {
 		return "", fmt.Errorf("reading .env file: %w", err)
 	}
 
-	required := []string{"CLAUDE_CODE_OAUTH_TOKEN", "GIT_TOKEN"}
-	for _, key := range required {
+	var missing []string
+	for _, key := range spec.EnvKeys() {
 		if !keys[key] {
-			return "", fmt.Errorf("validating .env file: missing required key %s", key)
+			missing = append(missing, key)
 		}
+	}
+	if len(missing) > 0 {
+		return "", fmt.Errorf("validating .env file: missing required key(s): %s", strings.Join(missing, ", "))
 	}
 
 	return envPath, nil

--- a/internal/config/envfile_test.go
+++ b/internal/config/envfile_test.go
@@ -47,9 +47,9 @@ func TestValidateEnvFile_Errors(t *testing.T) {
 		wantErr string
 	}{
 		{"missing file", false, "", "opening .env file"},
-		{"missing CLAUDE_CODE_OAUTH_TOKEN", true, "GIT_TOKEN=ghp_xxx\n", "validating .env file: missing required key CLAUDE_CODE_OAUTH_TOKEN"},
-		{"missing GIT_TOKEN", true, "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-xxx\n", "validating .env file: missing required key GIT_TOKEN"},
-		{"empty file", true, "", "validating .env file: missing required key CLAUDE_CODE_OAUTH_TOKEN"},
+		{"missing CLAUDE_CODE_OAUTH_TOKEN", true, "GIT_TOKEN=ghp_xxx\n", "missing required key(s): CLAUDE_CODE_OAUTH_TOKEN"},
+		{"missing GIT_TOKEN", true, "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-xxx\n", "missing required key(s): GIT_TOKEN"},
+		{"empty file", true, "", "missing required key(s): CLAUDE_CODE_OAUTH_TOKEN, GIT_TOKEN"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -68,6 +68,42 @@ func TestValidateEnvFile_Errors(t *testing.T) {
 				t.Errorf("ValidateEnvFile() error = %q, want it to contain %q", err.Error(), tc.wantErr)
 			}
 		})
+	}
+}
+
+func TestValidateEnvFileFor_SpecDriven(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	content := "CLAUDE_CODE_OAUTH_TOKEN=sk\nGIT_TOKEN=ghp\nREVIEW_GIT_TOKEN=rev\n"
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte(content), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	spec := MergeSecrets(SecretSpec{
+		"REVIEW_GIT_TOKEN": {Env: "REVIEW_GIT_TOKEN", AWSSecret: "horde/review"},
+	})
+	if _, err := ValidateEnvFileFor(dir, spec); err != nil {
+		t.Fatalf("ValidateEnvFileFor() error: %v", err)
+	}
+}
+
+func TestValidateEnvFileFor_NamesUnknownKey(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	content := "CLAUDE_CODE_OAUTH_TOKEN=sk\nGIT_TOKEN=ghp\n"
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte(content), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	spec := MergeSecrets(SecretSpec{
+		"STRIPE_API_KEY": {Env: "STRIPE_API_KEY", AWSSecret: "p/stripe"},
+	})
+	_, err := ValidateEnvFileFor(dir, spec)
+	if err == nil {
+		t.Fatal("expected error for missing STRIPE_API_KEY")
+	}
+	if !strings.Contains(err.Error(), "STRIPE_API_KEY") {
+		t.Errorf("error should name the missing key: %v", err)
 	}
 }
 

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -11,7 +11,8 @@ import (
 
 // ProjectConfig holds project-level horde settings from .horde/config.yaml.
 type ProjectConfig struct {
-	Mounts []string `yaml:"mounts"` // volume mounts in host:container format (host side relative to project root)
+	Mounts  []string   `yaml:"mounts"`            // volume mounts in host:container format (host side relative to project root)
+	Secrets SecretSpec `yaml:"secrets,omitempty"` // caller-declared env-var secrets, additive to canonical defaults
 }
 
 // LoadProjectConfig reads .horde/config.yaml from dir.

--- a/internal/config/secrets.go
+++ b/internal/config/secrets.go
@@ -1,0 +1,155 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Provider kind identifiers used by SecretSpec.ValidateForProvider.
+const (
+	ProviderDocker = "docker"
+	ProviderECS    = "aws-ecs"
+)
+
+// Canonical secret names auto-seeded with default sources.
+const (
+	SecretClaudeCodeOauthToken = "CLAUDE_CODE_OAUTH_TOKEN"
+	SecretGitToken             = "GIT_TOKEN"
+)
+
+// canonicalAWSSecretName returns the bootstrap-stack Secrets Manager name
+// for a canonical secret of the given project slug. Mirrors the names
+// hardcoded in internal/bootstrap/templates/stack.yaml.tmpl. The slug is
+// not known at config-load time, so the auto-seeded ECS source uses the
+// short name "horde-worker/<lower>" as a placeholder; the bootstrap
+// renderer treats the two canonicals specially anyway.
+func canonicalAWSSecretName(name string) string {
+	return "horde-worker/" + strings.ToLower(strings.ReplaceAll(name, "_", "-"))
+}
+
+// SecretSource declares how to resolve a single secret per provider kind.
+// Sources are additive — a single entry can carry multiple kinds, and the
+// active provider picks the matching one. Empty fields mean "no source for
+// that provider"; ValidateForProvider rejects entries that lack a source
+// matching the active provider.
+type SecretSource struct {
+	// Env is the host env-var name (read from .env) used by the docker
+	// provider. When empty the secret has no docker source.
+	Env string `yaml:"env,omitempty"`
+
+	// AWSSecret is the Secrets Manager secret name (or ARN) used by the
+	// ECS provider. When empty the secret has no ECS source.
+	AWSSecret string `yaml:"aws-secret,omitempty"`
+}
+
+// SecretSpec maps env-var names (as seen inside the worker container) to
+// their per-provider sources. The map key is the container env-var name.
+type SecretSpec map[string]SecretSource
+
+// DefaultSecrets returns the two canonical secrets with their default
+// sources: read from .env on docker, and from the bootstrap stack's
+// Secrets Manager entries on ECS. The bootstrap renderer recognizes the
+// canonical names and wires them through stack-managed CF parameters; the
+// AWSSecret field here is informational for ValidateForProvider only.
+func DefaultSecrets() SecretSpec {
+	return SecretSpec{
+		SecretClaudeCodeOauthToken: {
+			Env:       SecretClaudeCodeOauthToken,
+			AWSSecret: canonicalAWSSecretName(SecretClaudeCodeOauthToken),
+		},
+		SecretGitToken: {
+			Env:       SecretGitToken,
+			AWSSecret: canonicalAWSSecretName(SecretGitToken),
+		},
+	}
+}
+
+// MergeSecrets seeds DefaultSecrets() and applies caller overrides on top.
+// A caller entry replaces the default entry's sources entirely (no field-
+// level merge) — overriding the canonical name means the caller takes
+// full responsibility for both source kinds.
+func MergeSecrets(fromConfig SecretSpec) SecretSpec {
+	out := DefaultSecrets()
+	for name, src := range fromConfig {
+		out[name] = src
+	}
+	return out
+}
+
+// IsCanonical reports whether name is one of the two auto-seeded secrets.
+func IsCanonical(name string) bool {
+	return name == SecretClaudeCodeOauthToken || name == SecretGitToken
+}
+
+// ValidateForProvider returns an error if any entry in s lacks a source
+// matching the given provider kind. The error message lists every
+// unsourced secret so the caller can fix the config in one pass.
+func (s SecretSpec) ValidateForProvider(kind string) error {
+	var missing []string
+	for name, src := range s {
+		switch kind {
+		case ProviderDocker:
+			if src.Env == "" {
+				missing = append(missing, name)
+			}
+		case ProviderECS:
+			if src.AWSSecret == "" {
+				missing = append(missing, name)
+			}
+		default:
+			return fmt.Errorf("validating secrets: unknown provider kind %q", kind)
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	sort.Strings(missing)
+	return fmt.Errorf("validating secrets: provider %q has no source for: %s", kind, strings.Join(missing, ", "))
+}
+
+// EnvKeys returns the set of host env-var names referenced by the spec's
+// docker sources. Used by ValidateEnvFileFor to assert .env coverage.
+// Returned slice is sorted for stable error messages.
+func (s SecretSpec) EnvKeys() []string {
+	seen := map[string]struct{}{}
+	for _, src := range s {
+		if src.Env != "" {
+			seen[src.Env] = struct{}{}
+		}
+	}
+	keys := make([]string, 0, len(seen))
+	for k := range seen {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// ExtraAWSSecretNames returns the Secrets Manager names referenced by
+// non-canonical entries. The bootstrap renderer uses this to add IAM
+// grants and task-definition Secrets entries beyond the two canonicals.
+// Returned slice is sorted for deterministic template output.
+func (s SecretSpec) ExtraAWSSecretNames() []ExtraAWSSecret {
+	var out []ExtraAWSSecret
+	for name, src := range s {
+		if IsCanonical(name) {
+			continue
+		}
+		if src.AWSSecret == "" {
+			continue
+		}
+		out = append(out, ExtraAWSSecret{EnvName: name, SecretName: src.AWSSecret})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].EnvName < out[j].EnvName })
+	return out
+}
+
+// ExtraAWSSecret describes one caller-declared ECS secret beyond the two
+// canonicals. EnvName is the env-var name inside the worker container;
+// SecretName is the AWS Secrets Manager secret name (or ARN) the caller
+// pre-created.
+type ExtraAWSSecret struct {
+	EnvName    string
+	SecretName string
+}

--- a/internal/config/secrets_test.go
+++ b/internal/config/secrets_test.go
@@ -1,0 +1,162 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestDefaultSecrets_HasCanonicals(t *testing.T) {
+	d := DefaultSecrets()
+	if _, ok := d[SecretClaudeCodeOauthToken]; !ok {
+		t.Errorf("DefaultSecrets missing %s", SecretClaudeCodeOauthToken)
+	}
+	if _, ok := d[SecretGitToken]; !ok {
+		t.Errorf("DefaultSecrets missing %s", SecretGitToken)
+	}
+	if d[SecretGitToken].Env != SecretGitToken {
+		t.Errorf("default GIT_TOKEN env source = %q, want %q", d[SecretGitToken].Env, SecretGitToken)
+	}
+	if d[SecretGitToken].AWSSecret == "" {
+		t.Errorf("default GIT_TOKEN aws-secret source is empty")
+	}
+}
+
+func TestMergeSecrets_OverrideReplacesEntireEntry(t *testing.T) {
+	overrides := SecretSpec{
+		SecretGitToken: {Env: "MY_GIT_TOKEN"}, // no aws-secret
+		"REVIEW_GIT_TOKEN": {
+			Env:       "REVIEW_GIT_TOKEN",
+			AWSSecret: "horde/review-git-token",
+		},
+	}
+	merged := MergeSecrets(overrides)
+
+	got := merged[SecretGitToken]
+	if got.Env != "MY_GIT_TOKEN" {
+		t.Errorf("override GIT_TOKEN env = %q, want %q", got.Env, "MY_GIT_TOKEN")
+	}
+	if got.AWSSecret != "" {
+		t.Errorf("override GIT_TOKEN aws-secret should be empty, got %q", got.AWSSecret)
+	}
+	if _, ok := merged["REVIEW_GIT_TOKEN"]; !ok {
+		t.Errorf("merged spec missing REVIEW_GIT_TOKEN")
+	}
+	// Canonical not overridden stays at default.
+	if merged[SecretClaudeCodeOauthToken].Env != SecretClaudeCodeOauthToken {
+		t.Errorf("CLAUDE_CODE_OAUTH_TOKEN was unexpectedly altered")
+	}
+}
+
+func TestMergeSecrets_NoOverridesKeepsDefaults(t *testing.T) {
+	merged := MergeSecrets(nil)
+	if len(merged) != 2 {
+		t.Errorf("expected 2 default entries, got %d", len(merged))
+	}
+}
+
+func TestValidateForProvider_DockerRequiresEnv(t *testing.T) {
+	spec := SecretSpec{
+		"FOO": {AWSSecret: "horde/foo"},
+	}
+	err := spec.ValidateForProvider(ProviderDocker)
+	if err == nil {
+		t.Fatal("expected error for missing docker source")
+	}
+	if !strings.Contains(err.Error(), "FOO") || !strings.Contains(err.Error(), "docker") {
+		t.Errorf("error should name the unsourced secret and provider, got: %v", err)
+	}
+}
+
+func TestValidateForProvider_ECSRequiresAWSSecret(t *testing.T) {
+	spec := SecretSpec{
+		"BAR": {Env: "BAR"},
+	}
+	err := spec.ValidateForProvider(ProviderECS)
+	if err == nil {
+		t.Fatal("expected error for missing aws-secret source")
+	}
+	if !strings.Contains(err.Error(), "BAR") || !strings.Contains(err.Error(), "aws-ecs") {
+		t.Errorf("error should name the unsourced secret and provider, got: %v", err)
+	}
+}
+
+func TestValidateForProvider_HappyPath(t *testing.T) {
+	spec := MergeSecrets(SecretSpec{
+		"EXTRA": {Env: "EXTRA", AWSSecret: "horde/extra"},
+	})
+	if err := spec.ValidateForProvider(ProviderDocker); err != nil {
+		t.Errorf("docker validation: %v", err)
+	}
+	if err := spec.ValidateForProvider(ProviderECS); err != nil {
+		t.Errorf("ecs validation: %v", err)
+	}
+}
+
+func TestValidateForProvider_MultipleMissingListed(t *testing.T) {
+	spec := SecretSpec{
+		"A": {AWSSecret: "x"},
+		"B": {AWSSecret: "y"},
+	}
+	err := spec.ValidateForProvider(ProviderDocker)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "A") || !strings.Contains(msg, "B") {
+		t.Errorf("error should list both missing secrets, got: %v", err)
+	}
+}
+
+func TestEnvKeys_Sorted(t *testing.T) {
+	spec := SecretSpec{
+		"Z": {Env: "ZED"},
+		"A": {Env: "ALPHA"},
+		"M": {AWSSecret: "only-aws"},
+	}
+	keys := spec.EnvKeys()
+	want := []string{"ALPHA", "ZED"}
+	if len(keys) != len(want) {
+		t.Fatalf("EnvKeys = %v, want %v", keys, want)
+	}
+	for i := range want {
+		if keys[i] != want[i] {
+			t.Errorf("EnvKeys[%d] = %q, want %q", i, keys[i], want[i])
+		}
+	}
+}
+
+func TestExtraAWSSecretNames_ExcludesCanonicals(t *testing.T) {
+	spec := MergeSecrets(SecretSpec{
+		"STRIPE_KEY": {AWSSecret: "prepdesk/stripe"},
+	})
+	extras := spec.ExtraAWSSecretNames()
+	if len(extras) != 1 {
+		t.Fatalf("expected 1 extra, got %d: %+v", len(extras), extras)
+	}
+	if extras[0].EnvName != "STRIPE_KEY" || extras[0].SecretName != "prepdesk/stripe" {
+		t.Errorf("unexpected extra: %+v", extras[0])
+	}
+}
+
+func TestSecretSpec_YAMLRoundtrip(t *testing.T) {
+	src := []byte(`
+GIT_TOKEN:
+  env: GIT_TOKEN
+  aws-secret: horde/git-token
+REVIEW_GIT_TOKEN:
+  env: REVIEW_GIT_TOKEN
+  aws-secret: horde/review-git-token
+`)
+	var spec SecretSpec
+	if err := yaml.Unmarshal(src, &spec); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got := spec["GIT_TOKEN"].Env; got != "GIT_TOKEN" {
+		t.Errorf("GIT_TOKEN.env = %q", got)
+	}
+	if got := spec["REVIEW_GIT_TOKEN"].AWSSecret; got != "horde/review-git-token" {
+		t.Errorf("REVIEW_GIT_TOKEN.aws-secret = %q", got)
+	}
+}

--- a/internal/docs/content.go
+++ b/internal/docs/content.go
@@ -131,6 +131,11 @@ Schema
     mounts:
       - <host-path>:<container-path>
 
+    secrets:
+      <CONTAINER_ENV_VAR>:
+        env: <HOST_ENV_VAR>            # docker provider source
+        aws-secret: <SECRETS_MANAGER_NAME>  # ECS provider source
+
 Fields
 ------
 
@@ -152,6 +157,56 @@ mounts (list of strings, optional):
 
     The container's project root is /workspace — this is where horde
     clones the repo inside the container.
+
+secrets (map, optional):
+
+    Caller-declared secrets injected into the worker container as env
+    vars. The map key is the env-var name as seen inside the container.
+    Each entry can declare multiple per-provider sources; the active
+    provider picks the matching one.
+
+    Two source kinds are supported in v0.2:
+
+        env: <NAME>          The host env-var name to read from .env on
+                             the docker provider.
+        aws-secret: <NAME>   The AWS Secrets Manager secret name (no
+                             ARN) for the ECS provider. Caller is
+                             responsible for creating the secret before
+                             running 'horde bootstrap deploy'.
+
+    Two canonical secrets — CLAUDE_CODE_OAUTH_TOKEN and GIT_TOKEN —
+    are auto-seeded with their default sources, so you do not need to
+    declare them unless overriding. Re-declaring a canonical replaces
+    the default source map entirely (no field-level merge).
+
+    Validation: at 'horde launch' time, every declared secret must
+    have a source matching the active provider, and (for docker) the
+    referenced .env keys must exist. horde refuses to launch otherwise
+    with a single error message naming every missing secret/key.
+
+    Docker provider note: horde injects all keys from .env via
+    'docker run --env-file', so the host-side name is also visible
+    inside the container. A remap (host MY_REVIEW_TOKEN -> container
+    REVIEW_GIT_TOKEN) makes the container env include both names with
+    the same value. The contract is that the spec-declared container
+    name is set; horde does not isolate host-side names from the
+    container.
+
+    ECS note: extra aws-secret entries are baked into the task
+    definition by 'horde bootstrap init' / 'horde bootstrap deploy';
+    redeploy the stack after editing this list. Fargate caps secret
+    references per task definition at roughly 16 — practical projects
+    will not hit this, but mention it for transparency.
+
+    Example:
+
+        secrets:
+          REVIEW_GIT_TOKEN:
+            env: REVIEW_GIT_TOKEN
+            aws-secret: horde/review-git-token
+          STRIPE_API_KEY:
+            env: STRIPE_API_KEY
+            aws-secret: prepdesk/stripe-api-key
 
 File Location
 -------------
@@ -450,10 +505,18 @@ Security
 Validation
 ----------
 
-horde validates the .env file before every launch. It checks that both
-CLAUDE_CODE_OAUTH_TOKEN and GIT_TOKEN keys are present (but does not
-verify that the values are valid tokens — that fails later at clone
-or orc execution time).
+horde validates the .env file before every launch. The required keys
+are driven by the merged secret spec (see 'horde docs config'):
+
+  - The two canonical secrets, CLAUDE_CODE_OAUTH_TOKEN and GIT_TOKEN,
+    are always required unless overridden in .horde/config.yaml's
+    secrets: block.
+  - Any additional secret declared with an env: source contributes its
+    referenced host env-var name to the required set.
+
+If a key is missing, the launch fails with a single error message
+naming every missing key. Values are not verified — invalid tokens
+surface later at clone time or during orc execution.
 `
 
 const topicHydrate = `Hydrating Run Results

--- a/internal/provider/docker.go
+++ b/internal/provider/docker.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -128,6 +129,32 @@ func (p *DockerProvider) Launch(ctx context.Context, opts LaunchOpts) (*LaunchRe
 	}
 	if opts.EnvFile != "" {
 		args = append(args, "--env-file", opts.EnvFile)
+	}
+	// SecretEnvRemap: pass "-e CONTAINER_NAME" so docker forwards the
+	// value of horde's HOST_NAME process env var under CONTAINER_NAME
+	// inside the container. We must Setenv first when CONTAINER_NAME
+	// itself is not already present in the process env (the .env file
+	// keys are loaded at startup but indexed under HOST_NAME). Setting
+	// CONTAINER_NAME=<value of HOST_NAME> bridges the gap without
+	// putting the value on argv.
+	if len(opts.SecretEnvRemap) > 0 {
+		// Sort for deterministic argv order in tests and audit logs.
+		keys := make([]string, 0, len(opts.SecretEnvRemap))
+		for k := range opts.SecretEnvRemap {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, containerName := range keys {
+			hostName := opts.SecretEnvRemap[containerName]
+			if containerName != hostName {
+				if v, ok := os.LookupEnv(hostName); ok {
+					if err := os.Setenv(containerName, v); err != nil {
+						return nil, fmt.Errorf("setting env for secret remap: %w", err)
+					}
+				}
+			}
+			args = append(args, "-e", containerName)
+		}
 	}
 	for _, mount := range allMounts {
 		args = append(args, "-v", mount)

--- a/internal/provider/ecs.go
+++ b/internal/provider/ecs.go
@@ -141,6 +141,12 @@ func (f *ecsLogFollower) Close() error {
 }
 
 func (p *ECSProvider) Launch(ctx context.Context, opts LaunchOpts) (*LaunchResult, error) {
+	// Secret env vars (CLAUDE_CODE_OAUTH_TOKEN, GIT_TOKEN, and any extras
+	// declared in .horde/config.yaml's secrets: block) are not passed
+	// here. They live on the task definition's `secrets:` array, which
+	// is set at deploy time by the bootstrap CF template / @horde.io/cdk
+	// construct. RunTask cannot add secrets per launch — only environment
+	// overrides — so opts.SecretEnvRemap is intentionally ignored on ECS.
 	env := []ecstypes.KeyValuePair{
 		{Name: aws.String("REPO_URL"), Value: aws.String(opts.Repo)},
 		{Name: aws.String("TICKET"), Value: aws.String(opts.Ticket)},

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -46,6 +46,16 @@ type LaunchOpts struct {
 	Mounts   []string // volume mounts in docker format (host:container)
 	HomeDir  string   // home directory for workspace path resolution
 	OrcArgs  []string // extra orc flags passed through via -- (opaque)
+
+	// SecretEnvRemap declares container-env-var-name -> host-env-var-name
+	// pairs that the docker provider must inject beyond what --env-file
+	// covers. The provider passes "-e <containerName>" to docker run so
+	// docker reads the value from horde's process env (host env-vars are
+	// loaded from .env by config.ApplyDotEnvToProcess at startup) without
+	// putting values on argv. Identity mappings (container-name ==
+	// host-name) and the two canonical secrets are already covered by
+	// --env-file and need not appear here.
+	SecretEnvRemap map[string]string
 }
 
 // ValidateRunID rejects empty run IDs and IDs that would enable path

--- a/test/fixtures/test-repo/.orc/workflows/env-dump.yaml
+++ b/test/fixtures/test-repo/.orc/workflows/env-dump.yaml
@@ -1,0 +1,9 @@
+name: horde-test
+ticket-pattern: 'TEST-[\w-]+'
+phases:
+  - name: dump-env
+    type: script
+    run: |
+      mkdir -p .orc/artifacts/$TICKET
+      env > .orc/artifacts/$TICKET/env-dump.txt
+    timeout: 1

--- a/test/integration/bootstrap_aws_test.go
+++ b/test/integration/bootstrap_aws_test.go
@@ -39,7 +39,7 @@ func TestBootstrap_ValidateTemplate(t *testing.T) {
 		t.Fatalf("loading AWS config (profile=%q): %v", profile, err)
 	}
 
-	rendered, err := bootstrap.Render("hordetest")
+	rendered, err := bootstrap.Render("hordetest", nil)
 	if err != nil {
 		t.Fatalf("rendering template: %v", err)
 	}

--- a/test/integration/secrets_test.go
+++ b/test/integration/secrets_test.go
@@ -1,0 +1,141 @@
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestLaunchExtraSecretInjected verifies that a third secret declared in
+// .horde/config.yaml is injected into the worker container alongside the
+// two canonical secrets. The worker dumps its environment to a file in
+// the workspace; the test reads that file from the host and asserts the
+// value lands under the container env-var name.
+func TestLaunchExtraSecretInjected(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	h := newHarness(t)
+
+	// Two extras: STRIPE_API_KEY exercises the identity-mapping path
+	// (matching host/container names flow through --env-file unchanged)
+	// and REVIEW_GIT_TOKEN exercises the remap path (host .env key
+	// MY_REVIEW_TOKEN, container env-var REVIEW_GIT_TOKEN, injected via
+	// `docker run -e REVIEW_GIT_TOKEN`). With --env-file in play the
+	// host-side name (MY_REVIEW_TOKEN) is also forwarded into the
+	// container under its own name; that is documented v1 behavior and
+	// not asserted against here.
+	envContent := "CLAUDE_CODE_OAUTH_TOKEN=test-token\n" +
+		"GIT_TOKEN=test-token\n" +
+		"MY_REVIEW_TOKEN=review-token-value-xyz\n" +
+		"STRIPE_API_KEY=stripe-value-abc\n"
+	if err := os.WriteFile(filepath.Join(h.workDir, ".env"), []byte(envContent), 0o644); err != nil {
+		t.Fatalf("writing .env: %v", err)
+	}
+
+	configContent := `secrets:
+  REVIEW_GIT_TOKEN:
+    env: MY_REVIEW_TOKEN
+    aws-secret: horde/review-git-token
+  STRIPE_API_KEY:
+    env: STRIPE_API_KEY
+    aws-secret: prepdesk/stripe-api-key
+`
+	hordeDir := filepath.Join(h.workDir, ".horde")
+	if err := os.MkdirAll(hordeDir, 0o755); err != nil {
+		t.Fatalf("creating .horde dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(hordeDir, "config.yaml"), []byte(configContent), 0o644); err != nil {
+		t.Fatalf("writing .horde/config.yaml: %v", err)
+	}
+
+	// Inject the host env vars into the test process so the docker
+	// provider's SecretEnvRemap path can copy them via os.Setenv +
+	// docker -e <name>. (The .env file already covers the
+	// matching-name case; the remap path needs the value in the
+	// horde process env at launch time. The non-test horde binary
+	// gets this via config.ApplyDotEnvToProcess at startup.)
+	t.Setenv("MY_REVIEW_TOKEN", "review-token-value-xyz")
+	t.Setenv("STRIPE_API_KEY", "stripe-value-abc")
+
+	runID := h.Launch("TEST-secrets", "env-dump", 1*time.Minute)
+	h.WaitForOrc(runID, 1*time.Minute)
+
+	// env-dump.yaml writes env to .orc/artifacts/<ticket>/env-dump.txt
+	envDumpPath := filepath.Join(h.WorkspaceDir(runID), ".orc", "artifacts", "TEST-secrets", "env-dump.txt")
+	deadline := time.Now().Add(15 * time.Second)
+	var dump string
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(envDumpPath)
+		if err == nil {
+			dump = string(data)
+			break
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	if dump == "" {
+		t.Fatalf("env-dump.txt not produced at %s", envDumpPath)
+	}
+
+	// Canonical secrets always appear.
+	if !strings.Contains(dump, "CLAUDE_CODE_OAUTH_TOKEN=test-token") {
+		t.Errorf("env dump missing CLAUDE_CODE_OAUTH_TOKEN=test-token; dump:\n%s", dump)
+	}
+	if !strings.Contains(dump, "GIT_TOKEN=test-token") {
+		t.Errorf("env dump missing GIT_TOKEN=test-token; dump:\n%s", dump)
+	}
+
+	// Remap path: container env REVIEW_GIT_TOKEN gets the value of host
+	// .env key MY_REVIEW_TOKEN.
+	if !strings.Contains(dump, "REVIEW_GIT_TOKEN=review-token-value-xyz") {
+		t.Errorf("env dump missing REVIEW_GIT_TOKEN=review-token-value-xyz; dump:\n%s", dump)
+	}
+
+	// Identity path: matching container/host name flows through --env-file.
+	if !strings.Contains(dump, "STRIPE_API_KEY=stripe-value-abc") {
+		t.Errorf("env dump missing STRIPE_API_KEY=stripe-value-abc; dump:\n%s", dump)
+	}
+
+	// Note: MY_REVIEW_TOKEN (the host-side name) is also visible inside
+	// the container because docker --env-file forwards every key in .env.
+	// We intentionally do not assert against that — it is documented v1
+	// behavior. The contract is that the container *can* read the value
+	// under the spec-declared name (REVIEW_GIT_TOKEN); leakage of the
+	// host name is not part of the secret-isolation guarantee.
+}
+
+// TestLaunchSecretMissingFromEnvFails asserts that horde refuses to launch
+// when .horde/config.yaml declares a docker secret whose env: source is
+// not present in .env.
+func TestLaunchSecretMissingFromEnvFails(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	h := newHarness(t)
+
+	// .env from harness has only CLAUDE_CODE_OAUTH_TOKEN + GIT_TOKEN.
+	configContent := `secrets:
+  STRIPE_API_KEY:
+    env: STRIPE_API_KEY
+    aws-secret: prepdesk/stripe-api-key
+`
+	hordeDir := filepath.Join(h.workDir, ".horde")
+	if err := os.MkdirAll(hordeDir, 0o755); err != nil {
+		t.Fatalf("creating .horde dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(hordeDir, "config.yaml"), []byte(configContent), 0o644); err != nil {
+		t.Fatalf("writing .horde/config.yaml: %v", err)
+	}
+
+	_, stderr, err := h.runHordeFull("--provider", "docker", "launch", "--workflow", "env-dump", "TEST-missing-env-key")
+	if err == nil {
+		t.Fatal("expected launch to fail for missing STRIPE_API_KEY in .env")
+	}
+	if !strings.Contains(stderr, "STRIPE_API_KEY") {
+		t.Errorf("stderr should name missing key STRIPE_API_KEY, got:\n%s", stderr)
+	}
+}


### PR DESCRIPTION
## Summary

Closes the gap exposed by a consumer running on `@horde.io/cdk@0.1.0`:

- **Task-role IAM fix.** Worker entrypoint runs `aws s3 sync s3://$ARTIFACTS_BUCKET/horde-runs/$RUN_ID/sessions/` (`docker/entrypoint.sh:69`) which calls `ListObjectsV2` + `GetObject`. The CDK task role previously had only `PutObject` + `AbortMultipartUpload`, causing `AccessDenied` at runtime. Now mirrors the bootstrap CF template's task-role IAM (`internal/bootstrap/templates/stack.yaml.tmpl`) so the two onboarding paths stay in lockstep.
- **Auto-publish on tag (horde-4ay.7).** New `.github/workflows/publish.yml` fires on `v*` tags, builds + tests, and `npm publish --provenance --access public` via npm trusted-publisher OIDC. No `NODE_AUTH_TOKEN`, no secrets in the repo.
- **Version → 0.2.0.** Captures both the secrets index-signature feature from #8 (`aa2f34d`) and the IAM fix here. Example consumer bumped to `^0.2.0`.

The same consumer also reported that `JIRA_*` secrets declared in `.horde/config.yaml` weren't reaching the container — that's because npm still serves 0.1.0 (pre-#8). Publishing 0.2.0 fixes both problems together.

## Out-of-band steps before cutting `v0.2.0`

Trusted-publisher requires one-time UI setup that **cannot** be automated:

1. Go to https://www.npmjs.com/package/@horde.io/cdk/access
2. Add a GitHub Actions trusted publisher: repo `jorge-barreto/horde`, workflow `publish.yml`, job `publish-cdk`, environment empty.
3. After this PR merges: `git tag v0.2.0 && git push origin v0.2.0` — workflow fires, package lands on npm with provenance.

## Test plan

- [x] `cd cdk && npm ci && npm run build && npm test` — 77 passing, 5 stale snapshots regenerated to reflect the new IAM statements
- [x] Targeted assertion in `horde-worker.test.ts` covers both `ArtifactsWrite` (with `GetObject`) and the new `ArtifactsList` statement
- [x] Matrix snapshot test still confirms scoped services (s3/ssm/dynamodb) never resolve to `*`
- [ ] (post-merge) `cdk deploy` in consumer app, re-run the originally failing horde job: confirm Jira env vars present + S3 sync succeeds
- [ ] (post-merge) verify `npm view @horde.io/cdk version` returns `0.2.0` after tagging

## Related

- Closes `horde-4ay.7` (auto-publish workflow)
- Builds on #8 (`aa2f34d`, extensible secrets)