### PR TITLE
publish workflow: upgrade npm so trusted-publisher OIDC works

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,11 @@ jobs:
           cache: npm
           cache-dependency-path: cdk/package-lock.json
 
+      # Trusted-publisher OIDC publish requires npm >= 11.5.1; node 22 LTS
+      # ships npm 10.x, which sends the publish PUT unauthenticated and the
+      # registry 404s. Upgrade before any registry writes.
+      - run: npm install --global npm@latest
+
       - run: npm ci
 
       - run: npm run build


### PR DESCRIPTION
## Summary

The v0.2.0 publish run failed three times in a row with:

\`\`\`
npm notice publish Signed provenance statement with source and build information from GitHub Actions
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/@horde.io%2fcdk - Not found
\`\`\`

Root cause: Node 22 LTS (which \`setup-node@v4\` provisions) ships **npm 10.9.7**. Trusted-publisher OIDC for \`npm publish\` requires **npm >= 11.5.1** — that's the version where the registry exchange started honoring the GitHub Actions OIDC token on the publish path.

With npm 10.x, the publish PUT goes out unauthenticated. The registry returns 404 (not 403) because that's how npm masks "not authorized" for unauthenticated requests against scoped packages. Sigstore provenance signing is unrelated to npm auth — it succeeds, which is what made the failure mode confusing.

Fix: \`npm install --global npm@latest\` before any registry-touching step in the publish workflow.

## Test plan

- [ ] Merge this PR
- [ ] Re-run the failed \`v0.2.0\` workflow run from the Actions tab (the tag already exists, no need to bump)
- [ ] Confirm \`npm view @horde.io/cdk version\` returns \`0.2.0\`