### PR TITLE
publish workflow: bump node to 24 + cdk 0.2.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,17 +23,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Node 24: ships npm >= 11.5.1, which is required for trusted-publisher
+      # OIDC publish. Node 22 LTS still bundles npm 10.x; with npm 10 the
+      # publish PUT goes out unauthenticated and the registry returns E404
+      # (anonymous PUT on a scoped package is masked as 404, not 401/403, per
+      # npm docs). In-place upgrading via 'npm install -g npm@latest' is also
+      # currently broken on the hosted runner image — see
+      # actions/runner-images#13883 (promise-retry MODULE_NOT_FOUND mid-install).
+      # Bumping node-version is the canonical fix per npm's trusted-publishers
+      # docs example.
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
           cache: npm
           cache-dependency-path: cdk/package-lock.json
-
-      # Trusted-publisher OIDC publish requires npm >= 11.5.1; node 22 LTS
-      # ships npm 10.x, which sends the publish PUT unauthenticated and the
-      # registry 404s. Upgrade before any registry writes.
-      - run: npm install --global npm@latest
 
       - run: npm ci
 
@@ -41,4 +45,7 @@ jobs:
 
       - run: npm test
 
-      - run: npm publish --provenance --access public
+      # No --provenance flag: signing is on by default with trusted publishing
+      # since the npm 11 GA. No NODE_AUTH_TOKEN env: a legacy auth header
+      # would preempt the OIDC handshake.
+      - run: npm publish --access public

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@horde.io/cdk",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "AWS CDK construct that provisions the infrastructure required by horde (https://github.com/jorge-barreto/horde): ECS Fargate cluster, DynamoDB runs table, S3 artifacts bucket, SSM config parameter, EventBridge status sync, and scoped IAM.",
   "license": "MIT",
   "main": "lib/index.js",


### PR DESCRIPTION
## Summary

The `v0.2.0` publish kept failing with `E404` on the registry PUT despite sigstore provenance signing succeeding. This PR diagnoses, fixes, and bumps to `0.2.1` for a clean release.

### Root cause

Node 22 LTS ships **npm 10.9.7**. Trusted-publisher OIDC publish requires **npm >= 11.5.1**. With npm 10 the publish PUT goes out unauthenticated, and per npm docs an anonymous PUT on a scoped package is masked as **404 (not 401/403)** — which is why the failure looked like "missing package" instead of "missing auth." Sigstore provenance signing has its own OIDC flow independent of npm, so signing kept succeeding while the registry write failed.

### First fix attempt didn't land

`npm install -g npm@latest` (in #12) hit a known-broken hosted runner image — the cached npm 10.9.7 module tree is missing `promise-retry`, see [actions/runner-images#13883](https://github.com/actions/runner-images/issues/13883). The self-upgrade fails with `MODULE_NOT_FOUND` mid-install.

### What this PR does

- **`node-version: "24"`** in `setup-node@v4`. Node 24 ships npm 11+, sidesteps the broken cached npm 10. This is the canonical fix per [npm's own trusted-publishers docs](https://docs.npmjs.com/trusted-publishers/).
- **Drop `--provenance` flag.** Trusted-publisher publishes have provenance on by default since the [npm 11 GA](https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/).
- **Bump `cdk/package.json` to `0.2.1`.** A sigstore provenance entry was already minted for `0.2.0` (pointing nowhere on npm); cleaner to start fresh than to replay.

The `examples/cdk-consumer/package.json` stays at `^0.2.0` — caret range already accepts `0.2.1`.

## Test plan

- [ ] Merge
- [ ] `git tag v0.2.1 && git push origin v0.2.1`
- [ ] Confirm `npm view @horde.io/cdk version` returns `0.2.1`
- [ ] Confirm green provenance badge on the npm package page