### PR TITLE
cdk 0.2.2: add repository field for sigstore provenance verification

### DIFF
--- a/cdk/package.json
+++ b/cdk/package.json
@@ -1,8 +1,13 @@
 {
   "name": "@horde.io/cdk",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "AWS CDK construct that provisions the infrastructure required by horde (https://github.com/jorge-barreto/horde): ECS Fargate cluster, DynamoDB runs table, S3 artifacts bucket, SSM config parameter, EventBridge status sync, and scoped IAM.",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jorge-barreto/horde.git",
+    "directory": "cdk"
+  },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [


### PR DESCRIPTION
## Summary

The `v0.2.1` publish actually got past OIDC auth (the Node 24 / npm 11 fix worked) and reached npm's content validator — which rejected it with E422:

```
422 Unprocessable Entity - PUT https://registry.npmjs.org/@horde.io%2fcdk
Error verifying sigstore provenance bundle:
  Failed to validate repository information:
  package.json: "repository.url" is "", expected to match
  "https://github.com/jorge-barreto/horde" from provenance
```

The OIDC-signed sigstore provenance bundle embeds the GitHub repo it was built from. npm's validator cross-checks that against `package.json:repository.url` and rejects on mismatch. With no `repository` field at all (the `0.1.0` published manifest had none), the comparison is `"" vs "https://github.com/jorge-barreto/horde"` → reject.

## Fix

Add the canonical `repository` block. Includes `directory: "cdk"` so the npm package page deep-links into the right subdirectory of the monorepo.

```json
"repository": {
  "type": "git",
  "url": "git+https://github.com/jorge-barreto/horde.git",
  "directory": "cdk"
}
```

Bump to `0.2.2` since 0.2.1 minted a sigstore provenance entry pointing nowhere on npm.

## Test plan

- [x] `cd cdk && npm test` — 77 passing locally
- [ ] Merge
- [ ] `git tag v0.2.2 && git push origin v0.2.2`
- [ ] Confirm `npm view @horde.io/cdk version` returns `0.2.2`
- [ ] Confirm green provenance badge on the npm package page