### PR TITLE
horde list: add WORKFLOW column

### DIFF
--- a/cmd/horde/main.go
+++ b/cmd/horde/main.go
@@ -1141,11 +1141,16 @@ func removeWorkspace(ctx context.Context, dir string) error {
 
 func printRunTable(runs []*store.Run) {
 	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
-	fmt.Fprintln(w, "RUN ID\tTICKET\tBRANCH\tSTATUS\tDURATION\tCOST")
+	fmt.Fprintln(w, "RUN ID\tTICKET\tWORKFLOW\tBRANCH\tSTATUS\tDURATION\tCOST")
 	for _, run := range runs {
 		branch := run.Branch
 		if branch == "" {
 			branch = "(default)"
+		}
+
+		workflow := run.Workflow
+		if workflow == "" {
+			workflow = "-"
 		}
 
 		var duration time.Duration
@@ -1161,8 +1166,8 @@ func printRunTable(runs []*store.Run) {
 			cost = fmt.Sprintf("$%.2f", *run.TotalCostUSD)
 		}
 
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
-			run.ID, run.Ticket, branch, run.Status, duration, cost)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			run.ID, run.Ticket, workflow, branch, run.Status, duration, cost)
 	}
 	w.Flush()
 }

--- a/cmd/horde/main_test.go
+++ b/cmd/horde/main_test.go
@@ -2148,6 +2148,7 @@ func TestList_TableFormat(t *testing.T) {
 		ID:           "listrun00006",
 		Ticket:       "PROJ-42",
 		Branch:       "feature-x",
+		Workflow:     "implement-ticket",
 		Status:       store.StatusSuccess,
 		Repo:         "github.com/test/repo.git",
 		Provider:     "docker",
@@ -2188,6 +2189,12 @@ func TestList_TableFormat(t *testing.T) {
 	}
 	if !strings.Contains(outStr, "$4.52") {
 		t.Errorf("output missing '$4.52': %s", outStr)
+	}
+	if !strings.Contains(outStr, "WORKFLOW") {
+		t.Errorf("output missing WORKFLOW header: %s", outStr)
+	}
+	if !strings.Contains(outStr, "implement-ticket") {
+		t.Errorf("output missing workflow value 'implement-ticket': %s", outStr)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `WORKFLOW` column to `horde list` between `TICKET` and `BRANCH`, matching the field order on the `Run` struct and `horde status` output
- Empty workflows render as `-` (consistent with how `COST` shows `-` for in-progress runs)
- Pure presentation change — `Workflow` is already on the `Run` struct and round-tripped by both SQLite and DynamoDB stores

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./cmd/horde/ -run TestList_` passes
- [x] `TestList_TableFormat` extended to set `Workflow: "implement-ticket"` and assert both the `WORKFLOW` header and the value appear in output