### PR TITLE
source canonical repo from SSM config, not git remote

### DIFF
--- a/cdk/README.md
+++ b/cdk/README.md
@@ -28,6 +28,7 @@ const repo = new ecr.Repository(stack, "WorkerImage", {
 
 new HordeWorker(stack, "Horde", {
   projectSlug: "my-org-my-repo",
+  repo: "github.com/my-org/my-repo",
   workerImage: ecs.ContainerImage.fromEcrRepository(repo, "latest"),
   ecrRepository: repo,
   secrets: {
@@ -38,6 +39,12 @@ new HordeWorker(stack, "Horde", {
   },
 });
 ```
+
+`repo` is the canonical repository identifier in `host/path` form (no scheme,
+no trailing slash). The horde CLI reads it from SSM and uses it verbatim when
+writing or querying run records, so every CI runner and dev box launching
+against this stack writes to the same `by-repo` bucket — no drift from local
+git remote variations (with vs. without `.git`, https vs. ssh).
 
 ## Development
 

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@horde.io/cdk",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "AWS CDK construct that provisions the infrastructure required by horde (https://github.com/jorge-barreto/horde): ECS Fargate cluster, DynamoDB runs table, S3 artifacts bucket, SSM config parameter, EventBridge status sync, and scoped IAM.",
   "license": "MIT",
   "repository": {

--- a/cdk/src/horde-worker-props.ts
+++ b/cdk/src/horde-worker-props.ts
@@ -40,6 +40,18 @@ export interface HordeWorkerProps {
   readonly projectSlug: string;
 
   /**
+   * Canonical repository identifier for runs in this deployment, in
+   * `host/path` form (no scheme, no userinfo, no trailing slash). Examples:
+   * `github.com/example/myproj`, `gitlab.com/team/svc`. Whatever you set
+   * here becomes the canonical value: every horde CLI invocation against
+   * this stack reads it from SSM and uses it verbatim when writing or
+   * querying run records on the by-repo GSI, so all run history shares one
+   * bucket regardless of how individual launchers' git remotes are configured
+   * (e.g. with or without `.git` suffix, https vs ssh).
+   */
+  readonly repo: string;
+
+  /**
    * Container image to run as the worker task. Typically
    * `ecs.ContainerImage.fromEcrRepository(repo, "latest")`.
    */

--- a/cdk/src/horde-worker.ts
+++ b/cdk/src/horde-worker.ts
@@ -348,7 +348,7 @@ export class HordeWorker extends Construct {
       this.runsTable.tableName,
       '","ecr_repo_uri":"',
       props.ecrRepository.repositoryUri,
-      `","max_concurrent":${maxConcurrent},"default_timeout_minutes":${defaultTimeoutMinutes}}`,
+      `","repo":"${props.repo}","max_concurrent":${maxConcurrent},"default_timeout_minutes":${defaultTimeoutMinutes}}`,
     ]);
 
     this.configParameter = new ssm.StringParameter(this, "ConfigParameter", {

--- a/cdk/test/__snapshots__/horde-worker-matrix.test.ts.snap
+++ b/cdk/test/__snapshots__/horde-worker-matrix.test.ts.snap
@@ -495,7 +495,7 @@ exports[`HordeWorker matrix — default (no vpc, no bucket) matches the saved sn
               {
                 "Ref": "AWS::URLSuffix",
               },
-              "/horde-test","max_concurrent":5,"default_timeout_minutes":1440}",
+              "/horde-test","repo":"github.com/example/test","max_concurrent":5,"default_timeout_minutes":1440}",
             ],
           ],
         },
@@ -1819,7 +1819,7 @@ exports[`HordeWorker matrix — provided bucket matches the saved snapshot 1`] =
               {
                 "Ref": "AWS::URLSuffix",
               },
-              "/horde-test","max_concurrent":5,"default_timeout_minutes":1440}",
+              "/horde-test","repo":"github.com/example/test","max_concurrent":5,"default_timeout_minutes":1440}",
             ],
           ],
         },
@@ -3151,7 +3151,7 @@ exports[`HordeWorker matrix — provided vpc and bucket matches the saved snapsh
               {
                 "Ref": "AWS::URLSuffix",
               },
-              "/horde-test","max_concurrent":5,"default_timeout_minutes":1440}",
+              "/horde-test","repo":"github.com/example/test","max_concurrent":5,"default_timeout_minutes":1440}",
             ],
           ],
         },
@@ -4687,7 +4687,7 @@ exports[`HordeWorker matrix — provided vpc matches the saved snapshot 1`] = `
               {
                 "Ref": "AWS::URLSuffix",
               },
-              "/horde-test","max_concurrent":5,"default_timeout_minutes":1440}",
+              "/horde-test","repo":"github.com/example/test","max_concurrent":5,"default_timeout_minutes":1440}",
             ],
           ],
         },

--- a/cdk/test/__snapshots__/horde-worker.test.ts.snap
+++ b/cdk/test/__snapshots__/horde-worker.test.ts.snap
@@ -495,7 +495,7 @@ exports[`HordeWorker (5fh.3 skeleton) matches the saved snapshot 1`] = `
               {
                 "Ref": "AWS::URLSuffix",
               },
-              "/horde-test","max_concurrent":5,"default_timeout_minutes":1440}",
+              "/horde-test","repo":"github.com/example/test","max_concurrent":5,"default_timeout_minutes":1440}",
             ],
           ],
         },

--- a/cdk/test/horde-worker-matrix.test.ts
+++ b/cdk/test/horde-worker-matrix.test.ts
@@ -25,6 +25,7 @@ function buildStack(opts: MatrixOpts): { stack: Stack; template: Template } {
   const repo = ecr.Repository.fromRepositoryName(stack, "Repo", "horde-test");
   const props: HordeWorkerProps = {
     projectSlug: "test",
+    repo: "github.com/example/test",
     workerImage: ecs.ContainerImage.fromRegistry("public.ecr.aws/horde/test:latest"),
     ecrRepository: repo,
     secrets: {

--- a/cdk/test/horde-worker.test.ts
+++ b/cdk/test/horde-worker.test.ts
@@ -13,6 +13,7 @@ function synth() {
   const repo = ecr.Repository.fromRepositoryName(stack, "Repo", "horde-test");
   new HordeWorker(stack, "Horde", {
     projectSlug: "test",
+    repo: "github.com/example/test",
     workerImage: ecs.ContainerImage.fromRegistry("public.ecr.aws/horde/test:latest"),
     ecrRepository: repo,
     secrets: {
@@ -300,6 +301,7 @@ describe("HordeWorker (5fh.3 skeleton)", () => {
     const repo = ecr.Repository.fromRepositoryName(stack, "Repo", "horde-test");
     new HordeWorker(stack, "Horde", {
       projectSlug: "test",
+      repo: "github.com/example/test",
       workerImage: ecs.ContainerImage.fromRegistry("public.ecr.aws/horde/test:latest"),
       ecrRepository: repo,
       secrets: {
@@ -334,6 +336,7 @@ describe("HordeWorker (5fh.3 skeleton)", () => {
       "artifacts_bucket",
       "runs_table",
       "ecr_repo_uri",
+      "repo",
       "max_concurrent",
       "default_timeout_minutes",
     ]) {
@@ -343,6 +346,7 @@ describe("HordeWorker (5fh.3 skeleton)", () => {
     expect(valueStr).toContain('\\"ecs\\"');
     expect(valueStr).toContain('\\"max_concurrent\\":5');
     expect(valueStr).toContain('\\"default_timeout_minutes\\":1440');
+    expect(valueStr).toContain('\\"repo\\":\\"github.com/example/test\\"');
   });
 
   it("creates a CLI user managed policy with all six required Sids", () => {
@@ -402,6 +406,7 @@ describe("HordeWorker (5fh.3 skeleton)", () => {
       () =>
         new HordeWorker(stack, "Horde", {
           projectSlug: "test",
+          repo: "github.com/example/test",
           workerImage: ecs.ContainerImage.fromRegistry("public.ecr.aws/horde/test:latest"),
           ecrRepository: repo,
           secrets: {
@@ -518,6 +523,7 @@ describe("HordeWorker status-sync (5fh.12/13/14)", () => {
     const repo = ecr.Repository.fromRepositoryName(stack, "Repo", "horde-test");
     new HordeWorker(stack, "Horde", {
       projectSlug: "test",
+      repo: "github.com/example/test",
       workerImage: ecs.ContainerImage.fromRegistry("public.ecr.aws/horde/test:latest"),
       ecrRepository: repo,
       secrets: {

--- a/cmd/horde/bootstrap.go
+++ b/cmd/horde/bootstrap.go
@@ -84,7 +84,7 @@ func bootstrapInitCmd() *cli.Command {
 				return err
 			}
 			merged := config.MergeSecrets(projCfg.Secrets)
-			rendered, err := bootstrap.Render(slug, merged.ExtraAWSSecretNames())
+			rendered, err := bootstrap.Render(slug, repo, merged.ExtraAWSSecretNames())
 			if err != nil {
 				return err
 			}

--- a/cmd/horde/bootstrap_destroy.go
+++ b/cmd/horde/bootstrap_destroy.go
@@ -176,7 +176,7 @@ func emptyArtifactsBucket(ctx context.Context, cmd *cli.Command, awsCfg aws.Conf
 // problem) is treated as "nothing to check" — warn and proceed, since the
 // stack may already be partially torn down.
 func refuseIfActiveRuns(ctx context.Context, cmd *cli.Command) error {
-	_, st, _, _, _, cleanup, err := initProviderAndStoreWith(ctx, "aws-ecs", cmd.String("profile"), defaultFactoryDeps())
+	_, st, _, _, _, _, cleanup, err := initProviderAndStoreWith(ctx, "aws-ecs", cmd.String("profile"), defaultFactoryDeps())
 	if err != nil {
 		fmt.Fprintf(cmd.Writer, "warning: could not reach DynamoDB store to check for active runs (%v); proceeding with destroy\n", err)
 		return nil

--- a/cmd/horde/factory.go
+++ b/cmd/horde/factory.go
@@ -130,7 +130,7 @@ func initFromRunIDWith(ctx context.Context, provFlag, profile, runID string, dep
 	}
 
 	// Explicit provider flag, or run not found in SQLite.
-	prov, st, _, _, _, cleanup, err := initProviderAndStoreWith(ctx, provFlag, profile, deps)
+	prov, st, _, _, _, _, cleanup, err := initProviderAndStoreWith(ctx, provFlag, profile, deps)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
@@ -157,16 +157,19 @@ const defaultMaxConcurrentDocker = 100
 // *aws.Config is non-nil for aws-ecs (and auto-detect that lands on aws-ecs)
 // so callers can reuse the loaded config for downstream STS / SDK calls
 // (e.g. resolveLaunchedBy) instead of triggering a fresh awscfg.Load round
-// trip. nil for docker.
-func initProviderAndStoreWith(ctx context.Context, name, profile string, deps factoryDeps) (provider.Provider, store.Store, int, string, *aws.Config, func(), error) {
+// trip. nil for docker. The returned *config.HordeConfig follows the same
+// convention: populated for aws-ecs so callers can read deployment-scoped
+// values like the canonical repo string from SSM, nil for docker (which has
+// no SSM analog).
+func initProviderAndStoreWith(ctx context.Context, name, profile string, deps factoryDeps) (provider.Provider, store.Store, int, string, *aws.Config, *config.HordeConfig, func(), error) {
 	switch name {
 	case "docker":
 		prov := provider.NewDockerProvider()
 		st, cleanup, err := deps.openStore("docker")
 		if err != nil {
-			return nil, nil, 0, "", nil, nil, err
+			return nil, nil, 0, "", nil, nil, nil, err
 		}
-		return prov, st, defaultMaxConcurrentDocker, "docker", nil, cleanup, nil
+		return prov, st, defaultMaxConcurrentDocker, "docker", nil, nil, cleanup, nil
 	case "aws-ecs":
 		// Explicit aws-ecs: no docker fallback hint — the user asked
 		// for ECS, so a docker hint would be misleading.
@@ -176,7 +179,7 @@ func initProviderAndStoreWith(ctx context.Context, name, profile string, deps fa
 		// local mode" hint so docker-only users have an obvious recovery.
 		return initECSProviderAndStore(ctx, profile, deps, "auto-detecting provider", true)
 	default:
-		return nil, nil, 0, "", nil, nil, fmt.Errorf("unsupported provider %q: valid values are \"docker\" and \"aws-ecs\"", name)
+		return nil, nil, 0, "", nil, nil, nil, fmt.Errorf("unsupported provider %q: valid values are \"docker\" and \"aws-ecs\"", name)
 	}
 }
 
@@ -187,7 +190,7 @@ func initProviderAndStoreWith(ctx context.Context, name, profile string, deps fa
 // fallback hint to every error (used for the auto-detect path so docker-only
 // users see the recovery; suppressed for explicit aws-ecs which would be
 // misleading).
-func initECSProviderAndStore(ctx context.Context, profile string, deps factoryDeps, errPrefix string, withDockerHint bool) (provider.Provider, store.Store, int, string, *aws.Config, func(), error) {
+func initECSProviderAndStore(ctx context.Context, profile string, deps factoryDeps, errPrefix string, withDockerHint bool) (provider.Provider, store.Store, int, string, *aws.Config, *config.HordeConfig, func(), error) {
 	hint := ""
 	if withDockerHint {
 		hint = "\n\nhint: use --provider docker for local mode"
@@ -195,13 +198,13 @@ func initECSProviderAndStore(ctx context.Context, profile string, deps factoryDe
 
 	awsCfg, err := deps.loadAWSConfig(ctx, profile)
 	if err != nil {
-		return nil, nil, 0, "", nil, nil, fmt.Errorf("%s: %w%s", errPrefix, err, hint)
+		return nil, nil, 0, "", nil, nil, nil, fmt.Errorf("%s: %w%s", errPrefix, err, hint)
 	}
 	ssmClient := deps.newSSMClient(awsCfg)
 	hordeCfg, err := config.LoadFromSSM(ctx, ssmClient, resolveSSMPath())
 	if err != nil {
 		// Diagnostic returns a formatted string (not an error), so use %s.
-		return nil, nil, 0, "", nil, nil, fmt.Errorf("%s: %s%s", errPrefix, config.Diagnostic(err), hint)
+		return nil, nil, 0, "", nil, nil, nil, fmt.Errorf("%s: %s%s", errPrefix, config.Diagnostic(err), hint)
 	}
 	st, err := store.NewDynamoStore(ctx, awsCfg, hordeCfg.RunsTable)
 	if err != nil {
@@ -209,10 +212,10 @@ func initECSProviderAndStore(ctx context.Context, profile string, deps factoryDe
 		// the explicit-aws-ecs path; the auto-detect path keeps its own
 		// errPrefix and tacks on the hint.
 		if !withDockerHint {
-			return nil, nil, 0, "", nil, nil, fmt.Errorf("initializing aws-ecs store: %w", err)
+			return nil, nil, 0, "", nil, nil, nil, fmt.Errorf("initializing aws-ecs store: %w", err)
 		}
-		return nil, nil, 0, "", nil, nil, fmt.Errorf("%s: %w%s", errPrefix, err, hint)
+		return nil, nil, 0, "", nil, nil, nil, fmt.Errorf("%s: %w%s", errPrefix, err, hint)
 	}
 	prov := provider.NewECSProvider(ecs.NewFromConfig(awsCfg), cloudwatchlogs.NewFromConfig(awsCfg), s3.NewFromConfig(awsCfg), hordeCfg)
-	return prov, st, hordeCfg.MaxConcurrent, "aws-ecs", &awsCfg, func() {}, nil
+	return prov, st, hordeCfg.MaxConcurrent, "aws-ecs", &awsCfg, hordeCfg, func() {}, nil
 }

--- a/cmd/horde/factory_test.go
+++ b/cmd/horde/factory_test.go
@@ -45,7 +45,7 @@ func (f *fakeSSMClient) GetParameter(_ context.Context, _ *ssm.GetParameterInput
 }
 
 func validSSMJSON() string {
-	return `{"cluster_arn":"arn:aws:ecs:us-east-1:123456789012:cluster/horde","task_definition_arn":"arn:aws:ecs:us-east-1:123456789012:task-definition/horde-worker:1","subnets":["subnet-abc","subnet-def"],"security_group":"sg-123","log_group":"/ecs/horde-worker","log_stream_prefix":"ecs","artifacts_bucket":"my-horde-artifacts","runs_table":"horde-runs","ecr_repo_uri":"123456789012.dkr.ecr.us-east-1.amazonaws.com/horde-myproj","max_concurrent":5,"default_timeout_minutes":1440}`
+	return `{"cluster_arn":"arn:aws:ecs:us-east-1:123456789012:cluster/horde","task_definition_arn":"arn:aws:ecs:us-east-1:123456789012:task-definition/horde-worker:1","subnets":["subnet-abc","subnet-def"],"security_group":"sg-123","log_group":"/ecs/horde-worker","log_stream_prefix":"ecs","artifacts_bucket":"my-horde-artifacts","runs_table":"horde-runs","ecr_repo_uri":"123456789012.dkr.ecr.us-east-1.amazonaws.com/horde-myproj","repo":"github.com/example/myproj","max_concurrent":5,"default_timeout_minutes":1440}`
 }
 
 func TestInitProviderAndStore(t *testing.T) {
@@ -170,7 +170,7 @@ func TestInitProviderAndStore(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			prov, st, maxConcurrent, gotProvName, _, cleanup, err := initProviderAndStoreWith(context.Background(), tc.provName, "", tc.deps)
+			prov, st, maxConcurrent, gotProvName, _, _, cleanup, err := initProviderAndStoreWith(context.Background(), tc.provName, "", tc.deps)
 
 			if tc.wantErr {
 				if err == nil {
@@ -306,7 +306,7 @@ func TestAutoDetect_HintBlocksSeparatedByBlankLine(t *testing.T) {
 				}
 			},
 		}
-		_, _, _, _, _, _, err := initProviderAndStoreWith(context.Background(), "", "", deps)
+		_, _, _, _, _, _, _, err := initProviderAndStoreWith(context.Background(), "", "", deps)
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
@@ -326,7 +326,7 @@ func TestAutoDetect_HintBlocksSeparatedByBlankLine(t *testing.T) {
 				return aws.Config{}, fmt.Errorf("no AWS credentials")
 			},
 		}
-		_, _, _, _, _, _, err := initProviderAndStoreWith(context.Background(), "", "", deps)
+		_, _, _, _, _, _, _, err := initProviderAndStoreWith(context.Background(), "", "", deps)
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}

--- a/cmd/horde/main.go
+++ b/cmd/horde/main.go
@@ -162,7 +162,7 @@ kill some runs before launching more.`,
 				return fmt.Errorf("--workflow %q is invalid: must not contain '/', '\\', or '..'", workflow)
 			}
 
-			prov, st, maxConcurrent, provName, awsCfg, cleanup, err := initProviderAndStore(ctx, cmd)
+			prov, st, maxConcurrent, provName, awsCfg, hordeCfg, cleanup, err := initProviderAndStore(ctx, cmd)
 			if err != nil {
 				return err
 			}
@@ -195,7 +195,7 @@ kill some runs before launching more.`,
 				return fmt.Errorf("getting working directory: %w", err)
 			}
 
-			repo, err := config.RepoURL(cwd)
+			repo, err := resolveCanonicalRepo(hordeCfg, cwd)
 			if err != nil {
 				return err
 			}
@@ -736,7 +736,7 @@ include completed, failed, and killed runs.`,
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			all := cmd.Bool("all")
 
-			prov, st, _, _, _, cleanup, err := initProviderAndStoreWith(ctx, cmd.String("provider"), cmd.String("profile"), defaultFactoryDeps())
+			prov, st, _, _, _, hordeCfg, cleanup, err := initProviderAndStoreWith(ctx, cmd.String("provider"), cmd.String("profile"), defaultFactoryDeps())
 			if err != nil {
 				return err
 			}
@@ -752,7 +752,7 @@ include completed, failed, and killed runs.`,
 				return fmt.Errorf("getting working directory: %w", err)
 			}
 
-			repo, err := config.RepoURL(cwd)
+			repo, err := resolveCanonicalRepo(hordeCfg, cwd)
 			if err != nil {
 				return err
 			}
@@ -820,7 +820,7 @@ directories (all code changes will be lost).`,
 			},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			prov, st, _, _, _, cleanup, err := initProviderAndStoreWith(ctx, cmd.String("provider"), cmd.String("profile"), defaultFactoryDeps())
+			prov, st, _, _, _, hordeCfg, cleanup, err := initProviderAndStoreWith(ctx, cmd.String("provider"), cmd.String("profile"), defaultFactoryDeps())
 			if err != nil {
 				return err
 			}
@@ -875,7 +875,7 @@ directories (all code changes will be lost).`,
 			if err != nil {
 				return fmt.Errorf("getting working directory: %w", err)
 			}
-			repo, err := config.RepoURL(cwd)
+			repo, err := resolveCanonicalRepo(hordeCfg, cwd)
 			if err != nil {
 				return err
 			}
@@ -1289,13 +1289,27 @@ func resolveLaunchedBy(ctx context.Context, providerName string, cwd string, aws
 	}
 }
 
+// resolveCanonicalRepo returns the canonical repository identifier used to
+// scope run records. On aws-ecs the value comes from SSM (cfg.Repo), so every
+// CLI invocation against the same deployment writes and queries the same
+// string regardless of the local git remote. Docker has no SSM analog, so
+// it falls back to deriving from the local git remote — fine in practice
+// because the docker provider is single-user.
+func resolveCanonicalRepo(cfg *config.HordeConfig, cwd string) (string, error) {
+	if cfg != nil && cfg.Repo != "" {
+		return cfg.Repo, nil
+	}
+	return config.RepoURL(cwd)
+}
+
 // initProviderAndStore creates the Provider and Store based on the --provider flag.
 // Selection rule: "docker" → DockerProvider + SQLite; "aws-ecs" → ECS + DynamoDB;
 // "" → auto-detect via SSM. The returned *aws.Config is non-nil for aws-ecs so
 // callers can reuse the loaded config for STS / SDK calls without a duplicate
-// awscfg.Load round-trip.  Returns a cleanup function that must be deferred to
-// release store resources.
-func initProviderAndStore(ctx context.Context, cmd *cli.Command) (provider.Provider, store.Store, int, string, *aws.Config, func(), error) {
+// awscfg.Load round-trip. The returned *config.HordeConfig is also non-nil for
+// aws-ecs so callers can read deployment-scoped values (e.g. cfg.Repo). Returns
+// a cleanup function that must be deferred to release store resources.
+func initProviderAndStore(ctx context.Context, cmd *cli.Command) (provider.Provider, store.Store, int, string, *aws.Config, *config.HordeConfig, func(), error) {
 	return initProviderAndStoreWith(ctx, cmd.String("provider"), cmd.String("profile"), defaultFactoryDeps())
 }
 

--- a/cmd/horde/main_test.go
+++ b/cmd/horde/main_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/jorge-barreto/horde/internal/config"
 	"github.com/jorge-barreto/horde/internal/provider"
 	"github.com/jorge-barreto/horde/internal/store"
 )
@@ -3812,6 +3813,48 @@ func TestResults_LazyCompletion(t *testing.T) {
 	}
 	if !strings.Contains(outStr, "success") {
 		t.Errorf("output missing 'success': %s", outStr)
+	}
+}
+
+func TestResolveCanonicalRepo_FromSSMConfig(t *testing.T) {
+	t.Parallel()
+	cfg := &config.HordeConfig{Repo: "github.com/example/myproj"}
+	got, err := resolveCanonicalRepo(cfg, "/nonexistent/dir")
+	if err != nil {
+		t.Fatalf("resolveCanonicalRepo unexpected error: %v", err)
+	}
+	if got != "github.com/example/myproj" {
+		t.Errorf("resolveCanonicalRepo = %q, want %q", got, "github.com/example/myproj")
+	}
+}
+
+func TestResolveCanonicalRepo_FallsBackToGitRemote(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	run := func(args ...string) {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("command %v failed: %v\n%s", args, err, out)
+		}
+	}
+	run("git", "init")
+	run("git", "remote", "add", "origin", "https://github.com/example/fallback.git")
+
+	got, err := resolveCanonicalRepo(nil, dir)
+	if err != nil {
+		t.Fatalf("resolveCanonicalRepo(nil) unexpected error: %v", err)
+	}
+	if got != "github.com/example/fallback.git" {
+		t.Errorf("resolveCanonicalRepo(nil) = %q, want %q", got, "github.com/example/fallback.git")
+	}
+
+	got, err = resolveCanonicalRepo(&config.HordeConfig{Repo: ""}, dir)
+	if err != nil {
+		t.Fatalf("resolveCanonicalRepo(empty Repo) unexpected error: %v", err)
+	}
+	if got != "github.com/example/fallback.git" {
+		t.Errorf("resolveCanonicalRepo(empty Repo) = %q, want %q", got, "github.com/example/fallback.git")
 	}
 }
 

--- a/cmd/horde/push_test.go
+++ b/cmd/horde/push_test.go
@@ -104,6 +104,7 @@ func healthyHordeConfig() *config.HordeConfig {
 		ArtifactsBucket:       "bucket",
 		RunsTable:             "horde-runs",
 		EcrRepoURI:            "123456789012.dkr.ecr.us-east-1.amazonaws.com/horde-acme-widgets",
+		Repo:                  "github.com/acme/widgets",
 		MaxConcurrent:         1,
 		DefaultTimeoutMinutes: 1440,
 	}

--- a/examples/cdk-consumer/app.ts
+++ b/examples/cdk-consumer/app.ts
@@ -15,6 +15,12 @@ import { HordeWorker } from "@horde.io/cdk";
 //   git@github.com:acme/widgets.git  -> "acme-widgets"
 const SLUG = process.env.HORDE_PROJECT_SLUG ?? "acme-widgets";
 
+// REPO is the canonical repository identifier ("host/path" form, no scheme,
+// no trailing slash). Becomes the SSM `repo` value every horde CLI invocation
+// reads so all run records share one bucket on the by-repo GSI regardless of
+// how individual launchers' git remotes are configured.
+const REPO = process.env.HORDE_REPO ?? "github.com/acme/widgets";
+
 const app = new cdk.App();
 const stack = new cdk.Stack(app, "HordeWorkerStack", {
   stackName: `horde-${SLUG}`,
@@ -56,6 +62,7 @@ const gitSecret = new secretsmanager.Secret(stack, "GitToken", {
 
 const worker = new HordeWorker(stack, "Worker", {
   projectSlug: SLUG,
+  repo: REPO,
   ecrRepository: repo,
   workerImage: ecs.ContainerImage.fromEcrRepository(repo, "latest"),
   secrets: {

--- a/internal/bootstrap/template.go
+++ b/internal/bootstrap/template.go
@@ -16,6 +16,11 @@ var stackTemplateSource string
 // Render generates a CloudFormation stack template for the given project
 // slug. The slug is expected to come from Slug(remoteURL).
 //
+// repo is the canonical repository identifier in NormalizeRepoURL form
+// ("host/path", no scheme, trailing slash trimmed). It gets baked into
+// the rendered SSM config so every CLI invocation that hits this stack
+// reads the same value, regardless of how the local git remote is set up.
+//
 // extraSecrets are caller-declared aws-secret references beyond the two
 // canonicals (CLAUDE_CODE_OAUTH_TOKEN, GIT_TOKEN). Each one becomes:
 //
@@ -28,9 +33,12 @@ var stackTemplateSource string
 // The caller is responsible for ensuring the named Secrets Manager
 // entries actually exist before deploy. Pass nil/empty for the v0.2
 // canonical-only case (zero migration).
-func Render(slug string, extraSecrets []config.ExtraAWSSecret) ([]byte, error) {
+func Render(slug, repo string, extraSecrets []config.ExtraAWSSecret) ([]byte, error) {
 	if strings.TrimSpace(slug) == "" {
 		return nil, fmt.Errorf("rendering stack template: slug is empty")
+	}
+	if strings.TrimSpace(repo) == "" {
+		return nil, fmt.Errorf("rendering stack template: repo is empty")
 	}
 	tmpl, err := template.New("stack").Option("missingkey=error").Parse(stackTemplateSource)
 	if err != nil {
@@ -39,9 +47,11 @@ func Render(slug string, extraSecrets []config.ExtraAWSSecret) ([]byte, error) {
 	var buf bytes.Buffer
 	data := struct {
 		Slug         string
+		Repo         string
 		ExtraSecrets []config.ExtraAWSSecret
 	}{
 		Slug:         slug,
+		Repo:         repo,
 		ExtraSecrets: extraSecrets,
 	}
 	if err := tmpl.Execute(&buf, data); err != nil {

--- a/internal/bootstrap/template_test.go
+++ b/internal/bootstrap/template_test.go
@@ -24,7 +24,7 @@ func TestRender_EmptySlug(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			out, err := Render(tc.in, nil)
+			out, err := Render(tc.in, "github.com/example/myproj", nil)
 			if err == nil {
 				t.Fatalf("expected error for slug %q, got nil", tc.in)
 			}
@@ -38,9 +38,36 @@ func TestRender_EmptySlug(t *testing.T) {
 	}
 }
 
+func TestRender_EmptyRepo(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{"empty", ""},
+		{"whitespace", "   "},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			out, err := Render("myproj", tc.in, nil)
+			if err == nil {
+				t.Fatalf("expected error for repo %q, got nil", tc.in)
+			}
+			if !strings.Contains(err.Error(), "repo is empty") {
+				t.Errorf("error message %q does not contain %q", err.Error(), "repo is empty")
+			}
+			if out != nil {
+				t.Errorf("expected nil bytes, got %d bytes", len(out))
+			}
+		})
+	}
+}
+
 func TestRender_ValidYAML(t *testing.T) {
 	t.Parallel()
-	out, err := Render("myproj", nil)
+	out, err := Render("myproj", "github.com/example/myproj", nil)
 	if err != nil {
 		t.Fatalf("Render returned error: %v", err)
 	}
@@ -64,7 +91,7 @@ func TestRender_ValidYAML(t *testing.T) {
 
 func TestRender_ContainsSlug(t *testing.T) {
 	t.Parallel()
-	out, err := Render("myproj", nil)
+	out, err := Render("myproj", "github.com/example/myproj", nil)
 	if err != nil {
 		t.Fatalf("Render returned error: %v", err)
 	}
@@ -93,7 +120,7 @@ func TestRender_ContainsSlug(t *testing.T) {
 
 func TestRender_ResourcesPresent(t *testing.T) {
 	t.Parallel()
-	out, err := Render("myproj", nil)
+	out, err := Render("myproj", "github.com/example/myproj", nil)
 	if err != nil {
 		t.Fatalf("Render returned error: %v", err)
 	}
@@ -156,7 +183,7 @@ func TestRender_ResourcesPresent(t *testing.T) {
 
 func TestRender_RunsTableGSIs(t *testing.T) {
 	t.Parallel()
-	out, err := Render("myproj", nil)
+	out, err := Render("myproj", "github.com/example/myproj", nil)
 	if err != nil {
 		t.Fatalf("Render returned error: %v", err)
 	}
@@ -200,7 +227,7 @@ func TestRender_RunsTableGSIs(t *testing.T) {
 
 func TestRender_OutputsPresent(t *testing.T) {
 	t.Parallel()
-	out, err := Render("myproj", nil)
+	out, err := Render("myproj", "github.com/example/myproj", nil)
 	if err != nil {
 		t.Fatalf("Render returned error: %v", err)
 	}
@@ -243,7 +270,7 @@ func TestRender_OutputsPresent(t *testing.T) {
 
 func TestRender_ParametersPresent(t *testing.T) {
 	t.Parallel()
-	out, err := Render("myproj", nil)
+	out, err := Render("myproj", "github.com/example/myproj", nil)
 	if err != nil {
 		t.Fatalf("Render returned error: %v", err)
 	}
@@ -274,7 +301,7 @@ func TestRender_ParametersPresent(t *testing.T) {
 // common secret prefixes never appear in the output.
 func TestRender_NoSecretsLeaked(t *testing.T) {
 	t.Parallel()
-	out, err := Render("myproj", nil)
+	out, err := Render("myproj", "github.com/example/myproj", nil)
 	if err != nil {
 		t.Fatalf("Render returned error: %v", err)
 	}
@@ -305,7 +332,7 @@ func TestRender_NoSecretsLeaked(t *testing.T) {
 
 func TestRender_TaskDefSecrets(t *testing.T) {
 	t.Parallel()
-	out, err := Render("myproj", nil)
+	out, err := Render("myproj", "github.com/example/myproj", nil)
 	if err != nil {
 		t.Fatalf("Render returned error: %v", err)
 	}
@@ -361,7 +388,7 @@ func TestRender_TaskDefSecrets(t *testing.T) {
 
 func TestRender_TaskRoleHasPolicies(t *testing.T) {
 	t.Parallel()
-	out, err := Render("myproj", nil)
+	out, err := Render("myproj", "github.com/example/myproj", nil)
 	if err != nil {
 		t.Fatalf("Render returned error: %v", err)
 	}
@@ -417,7 +444,7 @@ func TestRender_TaskRoleHasPolicies(t *testing.T) {
 
 func TestRender_CliPolicyStatements(t *testing.T) {
 	t.Parallel()
-	out, err := Render("myproj", nil)
+	out, err := Render("myproj", "github.com/example/myproj", nil)
 	if err != nil {
 		t.Fatalf("Render returned error: %v", err)
 	}
@@ -469,7 +496,7 @@ func TestRender_CliPolicyStatements(t *testing.T) {
 
 func TestRender_SsmConfigParameter(t *testing.T) {
 	t.Parallel()
-	out, err := Render("myproj", nil)
+	out, err := Render("myproj", "github.com/example/myproj", nil)
 	if err != nil {
 		t.Fatalf("Render returned error: %v", err)
 	}
@@ -480,17 +507,20 @@ func TestRender_SsmConfigParameter(t *testing.T) {
 	for _, key := range []string{
 		"cluster_arn", "task_definition_arn", "subnets", "security_group",
 		"assign_public_ip", "log_group", "log_stream_prefix", "artifacts_bucket",
-		"runs_table", "ecr_repo_uri", "max_concurrent", "default_timeout_minutes",
+		"runs_table", "ecr_repo_uri", "repo", "max_concurrent", "default_timeout_minutes",
 	} {
 		if !strings.Contains(s, `"`+key+`"`) {
 			t.Errorf("SSM parameter JSON missing key %q", key)
 		}
 	}
+	if !strings.Contains(s, `"repo":"github.com/example/myproj"`) {
+		t.Errorf("SSM parameter JSON missing repo value substitution")
+	}
 }
 
 func TestRender_StatusLambdaPython(t *testing.T) {
 	t.Parallel()
-	out, err := Render("myproj", nil)
+	out, err := Render("myproj", "github.com/example/myproj", nil)
 	if err != nil {
 		t.Fatalf("Render returned error: %v", err)
 	}
@@ -539,7 +569,7 @@ func TestRender_ExtraSecrets_TaskDefAndIAM(t *testing.T) {
 		{EnvName: "STRIPE_API_KEY", SecretName: "prepdesk/stripe-api-key"},
 		{EnvName: "REVIEW_GIT_TOKEN", SecretName: "horde/review-git-token"},
 	}
-	out, err := Render("myproj", extras)
+	out, err := Render("myproj", "github.com/example/myproj", extras)
 	if err != nil {
 		t.Fatalf("Render returned error: %v", err)
 	}
@@ -583,7 +613,7 @@ func TestRender_ExtraSecrets_TaskDefAndIAM(t *testing.T) {
 
 func TestRender_NoExtras_NoExtraLines(t *testing.T) {
 	t.Parallel()
-	out, err := Render("myproj", nil)
+	out, err := Render("myproj", "github.com/example/myproj", nil)
 	if err != nil {
 		t.Fatalf("Render returned error: %v", err)
 	}
@@ -604,7 +634,7 @@ func TestRender_CfnLint(t *testing.T) {
 	if err != nil {
 		t.Skip("cfn-lint not installed")
 	}
-	out, err := Render("myproj", nil)
+	out, err := Render("myproj", "github.com/example/myproj", nil)
 	if err != nil {
 		t.Fatalf("Render returned error: %v", err)
 	}

--- a/internal/bootstrap/templates/stack.yaml.tmpl
+++ b/internal/bootstrap/templates/stack.yaml.tmpl
@@ -468,7 +468,7 @@ Resources:
       Value:
         Fn::Sub:
           - |
-            {"cluster_arn":"${ClusterArn}","task_definition_arn":"${TaskDefArn}","subnets":["${PrivateSubnet1Id}","${PrivateSubnet2Id}"],"security_group":"${SecurityGroupId}","assign_public_ip":"DISABLED","log_group":"${LogGroupName}","log_stream_prefix":"ecs","artifacts_bucket":"${BucketName}","runs_table":"${RunsTableName}","ecr_repo_uri":"${EcrUri}","max_concurrent":20,"default_timeout_minutes":1440}
+            {"cluster_arn":"${ClusterArn}","task_definition_arn":"${TaskDefArn}","subnets":["${PrivateSubnet1Id}","${PrivateSubnet2Id}"],"security_group":"${SecurityGroupId}","assign_public_ip":"DISABLED","log_group":"${LogGroupName}","log_stream_prefix":"ecs","artifacts_bucket":"${BucketName}","runs_table":"${RunsTableName}","ecr_repo_uri":"${EcrUri}","repo":"{{.Repo}}","max_concurrent":20,"default_timeout_minutes":1440}
           - ClusterArn:
               Fn::GetAtt: [EcsCluster, Arn]
             TaskDefArn:

--- a/internal/config/ssm.go
+++ b/internal/config/ssm.go
@@ -125,9 +125,15 @@ type HordeConfig struct {
 	// e.g. "123456789012.dkr.ecr.us-east-1.amazonaws.com/horde-myproj".
 	// Populated by the bootstrap CloudFormation stack and consumed by
 	// `horde push` to discover where to push the worker image.
-	EcrRepoURI            string   `json:"ecr_repo_uri"`
-	MaxConcurrent         int      `json:"max_concurrent"`
-	DefaultTimeoutMinutes int      `json:"default_timeout_minutes"`
+	EcrRepoURI string `json:"ecr_repo_uri"`
+	// Repo is the canonical repository identifier for runs in this deployment,
+	// in NormalizeRepoURL form ("host/path", no scheme, no userinfo, no
+	// trailing slash). Every CLI invocation that writes or queries the runs
+	// table uses this exact string, so all run records share one bucket on
+	// the by-repo GSI regardless of how the local git remote is configured.
+	Repo                  string `json:"repo"`
+	MaxConcurrent         int    `json:"max_concurrent"`
+	DefaultTimeoutMinutes int    `json:"default_timeout_minutes"`
 }
 
 // Validate checks that all required fields are present and valid.
@@ -159,6 +165,9 @@ func (c *HordeConfig) Validate() error {
 	}
 	if c.EcrRepoURI == "" {
 		missing = append(missing, "ecr_repo_uri")
+	}
+	if c.Repo == "" {
+		missing = append(missing, "repo")
 	}
 	if len(missing) > 0 {
 		return fmt.Errorf("validating horde config: missing required fields: %s", strings.Join(missing, ", "))

--- a/internal/config/ssm_test.go
+++ b/internal/config/ssm_test.go
@@ -25,6 +25,7 @@ func validHordeFields() map[string]interface{} {
 		"artifacts_bucket":        "my-horde-artifacts",
 		"runs_table":              "horde-runs",
 		"ecr_repo_uri":            "123456789012.dkr.ecr.us-east-1.amazonaws.com/horde-myproj",
+		"repo":                    "github.com/example/myproj",
 		"max_concurrent":          5,
 		"default_timeout_minutes": 1440,
 	}
@@ -237,6 +238,9 @@ func TestParseHordeConfig_Valid(t *testing.T) {
 	if cfg.EcrRepoURI != "123456789012.dkr.ecr.us-east-1.amazonaws.com/horde-myproj" {
 		t.Errorf("EcrRepoURI = %q, want %q", cfg.EcrRepoURI, "123456789012.dkr.ecr.us-east-1.amazonaws.com/horde-myproj")
 	}
+	if cfg.Repo != "github.com/example/myproj" {
+		t.Errorf("Repo = %q, want %q", cfg.Repo, "github.com/example/myproj")
+	}
 	if cfg.MaxConcurrent != 5 {
 		t.Errorf("MaxConcurrent = %d, want 5", cfg.MaxConcurrent)
 	}
@@ -257,6 +261,7 @@ func TestParseHordeConfig_JSONRoundTrip(t *testing.T) {
 		ArtifactsBucket:       "my-horde-artifacts",
 		RunsTable:             "horde-runs",
 		EcrRepoURI:            "123456789012.dkr.ecr.us-east-1.amazonaws.com/horde-myproj",
+		Repo:                  "github.com/example/myproj",
 		MaxConcurrent:         5,
 		DefaultTimeoutMinutes: 1440,
 	}
@@ -271,7 +276,7 @@ func TestParseHordeConfig_JSONRoundTrip(t *testing.T) {
 	wantKeys := []string{
 		"cluster_arn", "task_definition_arn", "subnets", "security_group",
 		"log_group", "log_stream_prefix", "artifacts_bucket", "runs_table",
-		"ecr_repo_uri", "max_concurrent", "default_timeout_minutes",
+		"ecr_repo_uri", "repo", "max_concurrent", "default_timeout_minutes",
 	}
 	for _, key := range wantKeys {
 		if _, ok := m[key]; !ok {
@@ -336,6 +341,11 @@ func TestParseHordeConfig_MissingFields(t *testing.T) {
 			name:    "missing ecr_repo_uri",
 			mutate:  func(m map[string]interface{}) { delete(m, "ecr_repo_uri") },
 			wantErr: []string{"missing required fields: ecr_repo_uri"},
+		},
+		{
+			name:    "missing repo",
+			mutate:  func(m map[string]interface{}) { delete(m, "repo") },
+			wantErr: []string{"missing required fields: repo"},
 		},
 		{
 			name: "multiple missing",
@@ -496,6 +506,7 @@ func TestHordeConfig_Validate_AllFieldsPresent(t *testing.T) {
 		ArtifactsBucket:       "my-bucket",
 		RunsTable:             "horde-runs",
 		EcrRepoURI:            "123.dkr.ecr.us-east-1.amazonaws.com/horde-x",
+		Repo:                  "github.com/example/myproj",
 		MaxConcurrent:         1,
 		DefaultTimeoutMinutes: 1,
 	}
@@ -516,6 +527,7 @@ func TestHordeConfig_Validate_AssignPublicIp(t *testing.T) {
 		ArtifactsBucket:       "my-bucket",
 		RunsTable:             "horde-runs",
 		EcrRepoURI:            "123.dkr.ecr.us-east-1.amazonaws.com/horde-x",
+		Repo:                  "github.com/example/myproj",
 		MaxConcurrent:         1,
 		DefaultTimeoutMinutes: 1,
 	}

--- a/internal/provider/ecs_test.go
+++ b/internal/provider/ecs_test.go
@@ -162,6 +162,7 @@ func testHordeConfig() *config.HordeConfig {
 		LogStreamPrefix:       "ecs",
 		ArtifactsBucket:       "my-horde-artifacts",
 		RunsTable:             "horde-runs",
+		Repo:                  "github.com/example/myproj",
 		MaxConcurrent:         5,
 		DefaultTimeoutMinutes: 1440,
 	}

--- a/test/integration/bootstrap_aws_test.go
+++ b/test/integration/bootstrap_aws_test.go
@@ -39,7 +39,7 @@ func TestBootstrap_ValidateTemplate(t *testing.T) {
 		t.Fatalf("loading AWS config (profile=%q): %v", profile, err)
 	}
 
-	rendered, err := bootstrap.Render("hordetest", nil)
+	rendered, err := bootstrap.Render("hordetest", "github.com/example/hordetest", nil)
 	if err != nil {
 		t.Fatalf("rendering template: %v", err)
 	}


### PR DESCRIPTION
## Summary

- `horde list` (and friends) keyed runs-table queries on `config.RepoURL(cwd)`, which preserves whatever path the local `git remote` reports. Dev boxes wrote runs under `github.com/org/proj.git`; GitHub Actions runners wrote them under `github.com/org/proj`. `horde list` from a dev box only saw the first bucket.
- Moves the canonical `repo` string into the SSM config (alongside `runs_table`, `ecr_repo_uri`, etc.) so every CLI invocation against a given deployment reads and writes the same value. Bootstrap CFN and the @horde.io/cdk construct both emit it; the CLI consumes it via a new `resolveCanonicalRepo` helper (with `RepoURL(cwd)` fallback for docker, which has no SSM analog).
- Slug-derivation paths (bootstrap, push, `resolveSSMPath`) stay on git remote since they run before SSM is loaded.

**Breaking change for @horde.io/cdk consumers:** `repo` is now a required prop. Bumped to **0.3.0**.

**Migration deferred:** existing dynamo rows still under stale `repo` keys (e.g. 109 rows under `…prepdesk.git`, 20 under `…prepdesk` in the prepdesk table) are not rewritten by this PR — file a follow-up to canonicalize them. New runs post-deploy land under the SSM-sourced value.

## Test plan

- [x] `make unit-test`
- [x] `make integration-test` (~6m, docker provider unaffected)
- [x] `make vet`
- [x] `cd cdk && npm test` (77 tests, snapshots regenerated)
- [ ] After merge + `cdk deploy` against a real stack: confirm a run launched from CI and a run launched from a dev box both appear in `horde list --all` from either side.