### PR TITLE
Per-launch environment variables: horde launch --env KEY=VALUE (#22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ All commands require a provider. For local Docker mode, pass `--provider docker`
 horde launch --provider docker --workflow implement-ticket PROJ-123
 horde launch --provider docker --workflow implement-ticket PROJ-123 --branch feature/xyz
 horde launch --provider docker --workflow bugfix PROJ-123 --timeout 30m
+horde launch --provider docker --workflow implement-ticket PROJ-123 --env PROMPT_VARIANT=v3 --env DEBUG=1
 
 # Monitor
 horde status <run-id>

--- a/SPEC.md
+++ b/SPEC.md
@@ -85,7 +85,7 @@ The status Lambda:
 ## CLI Commands
 
 ```
-horde launch --workflow=<name> [--branch=<branch>] [--timeout=<duration>] [--force] <ticket>
+horde launch --workflow=<name> [--branch=<branch>] [--timeout=<duration>] [--force] [--env=<KEY=VALUE>]... <ticket>
 horde status <run-id>
 horde logs <run-id> [--follow]
 horde kill <run-id>

--- a/cmd/horde/main.go
+++ b/cmd/horde/main.go
@@ -147,7 +147,7 @@ kill some runs before launching more.`,
 			&cli.StringSliceFlag{
 				Name:    "env",
 				Aliases: []string{"e"},
-				Usage:   "Set a per-launch env var (KEY=VALUE); repeatable. Overrides project secrets of the same key on docker (see `horde docs config` for the ECS caveat). Applies to launch only — `horde retry` does not carry it forward.",
+				Usage:   "Set a per-launch env var (KEY=VALUE); repeatable. Overrides project secrets of the same key on docker (see 'horde docs config' for the ECS caveat). Applies to launch only; 'horde retry' does not carry it forward.",
 			},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {

--- a/cmd/horde/main.go
+++ b/cmd/horde/main.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"syscall"
@@ -142,6 +143,11 @@ kill some runs before launching more.`,
 				Name:  "force",
 				Usage: "Force launch even if already running",
 			},
+			&cli.StringSliceFlag{
+				Name:    "env",
+				Aliases: []string{"e"},
+				Usage:   "Set a per-launch env var (KEY=VALUE); repeatable. Overrides project secrets of the same key on docker (see `horde docs config` for the ECS caveat).",
+			},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			ticket := cmd.Args().First()
@@ -154,6 +160,11 @@ kill some runs before launching more.`,
 			workflow := strings.TrimSpace(cmd.String("workflow"))
 			timeout := cmd.Duration("timeout")
 			force := cmd.Bool("force")
+
+			extraEnv, err := parseEnvFlags(cmd.StringSlice("env"))
+			if err != nil {
+				return err
+			}
 
 			if workflow == "" {
 				return fmt.Errorf("--workflow is required (e.g. --workflow implement-ticket)")
@@ -200,9 +211,22 @@ kill some runs before launching more.`,
 				return err
 			}
 
-			envPath, _, secretRemap, err := resolveSecretsForLaunch(provName, cwd)
+			envPath, spec, secretRemap, err := resolveSecretsForLaunch(provName, cwd)
 			if err != nil {
 				return err
+			}
+
+			// On ECS a per-launch --env override of a declared secret has no
+			// effect: the secret lives on the task definition and AWS gives it
+			// precedence over the RunTask environment override. Warn rather
+			// than fail — the var is still injected, and non-secret keys (plus
+			// every key on docker) override as expected.
+			if provName == config.ProviderECS {
+				for k := range extraEnv {
+					if _, declared := spec[k]; declared {
+						fmt.Fprintf(os.Stderr, "warning: --env %s overrides a declared secret; on ECS the task-definition secret takes precedence, so this override will not take effect\n", k)
+					}
+				}
 			}
 
 			id, err := runid.Generate()
@@ -286,6 +310,7 @@ kill some runs before launching more.`,
 				HomeDir:        homeDir,
 				OrcArgs:        orcArgs,
 				SecretEnvRemap: secretRemap,
+				ExtraEnv:       extraEnv,
 			})
 			if err != nil {
 				failedStatus := store.StatusFailed
@@ -1052,6 +1077,44 @@ name, displays the full article.`,
 
 type liveCosts struct {
 	TotalCostUSD float64 `json:"total_cost_usd"`
+}
+
+// envKeyPattern matches a valid POSIX-style env-var name.
+var envKeyPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// reservedEnvKeys are the horde-managed control vars wired from other launch
+// flags / run metadata. A --env override of any of these would break the run,
+// so parseEnvFlags rejects them.
+var reservedEnvKeys = map[string]bool{
+	"REPO_URL":         true,
+	"TICKET":           true,
+	"BRANCH":           true,
+	"WORKFLOW":         true,
+	"RUN_ID":           true,
+	"ARTIFACTS_BUCKET": true,
+	"ORC_EXTRA_ARGS":   true,
+}
+
+// parseEnvFlags turns repeatable --env KEY=VALUE entries into a map. KEY must
+// be a valid env-var name and must not be one of the horde-managed control
+// vars. VALUE may be empty and may itself contain '='. On a duplicate key the
+// last occurrence wins (consistent with docker run -e).
+func parseEnvFlags(raw []string) (map[string]string, error) {
+	out := make(map[string]string, len(raw))
+	for _, entry := range raw {
+		key, val, found := strings.Cut(entry, "=")
+		if !found {
+			return nil, fmt.Errorf("parsing --env %q: expected KEY=VALUE", entry)
+		}
+		if !envKeyPattern.MatchString(key) {
+			return nil, fmt.Errorf("parsing --env %q: invalid key %q (must match [A-Za-z_][A-Za-z0-9_]*)", entry, key)
+		}
+		if reservedEnvKeys[key] {
+			return nil, fmt.Errorf("parsing --env %q: %q is reserved by horde and cannot be overridden", entry, key)
+		}
+		out[key] = val
+	}
+	return out, nil
 }
 
 // fetchLiveCost reads the current cost from a running container's costs.json.

--- a/cmd/horde/main.go
+++ b/cmd/horde/main.go
@@ -12,6 +12,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -146,7 +147,7 @@ kill some runs before launching more.`,
 			&cli.StringSliceFlag{
 				Name:    "env",
 				Aliases: []string{"e"},
-				Usage:   "Set a per-launch env var (KEY=VALUE); repeatable. Overrides project secrets of the same key on docker (see `horde docs config` for the ECS caveat).",
+				Usage:   "Set a per-launch env var (KEY=VALUE); repeatable. Overrides project secrets of the same key on docker (see `horde docs config` for the ECS caveat). Applies to launch only — `horde retry` does not carry it forward.",
 			},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
@@ -221,12 +222,8 @@ kill some runs before launching more.`,
 			// precedence over the RunTask environment override. Warn rather
 			// than fail — the var is still injected, and non-secret keys (plus
 			// every key on docker) override as expected.
-			if provName == config.ProviderECS {
-				for k := range extraEnv {
-					if _, declared := spec[k]; declared {
-						fmt.Fprintf(os.Stderr, "warning: --env %s overrides a declared secret; on ECS the task-definition secret takes precedence, so this override will not take effect\n", k)
-					}
-				}
+			for _, k := range secretCollisionsOnECS(provName, spec, extraEnv) {
+				fmt.Fprintf(os.Stderr, "warning: --env %s overrides a declared secret; on ECS the task-definition secret takes precedence, so this override will not take effect\n", k)
 			}
 
 			id, err := runid.Generate()
@@ -1115,6 +1112,25 @@ func parseEnvFlags(raw []string) (map[string]string, error) {
 		out[key] = val
 	}
 	return out, nil
+}
+
+// secretCollisionsOnECS returns the sorted --env keys that collide with a
+// declared secret when launching on ECS. Such overrides cannot take effect
+// there (AWS gives the task-definition secret precedence over the RunTask
+// environment override), so the caller warns the user. Returns nil for any
+// other provider, where per-launch --env overrides declared secrets normally.
+func secretCollisionsOnECS(provName string, spec config.SecretSpec, extraEnv map[string]string) []string {
+	if provName != config.ProviderECS {
+		return nil
+	}
+	var collisions []string
+	for k := range extraEnv {
+		if _, declared := spec[k]; declared {
+			collisions = append(collisions, k)
+		}
+	}
+	sort.Strings(collisions)
+	return collisions
 }
 
 // fetchLiveCost reads the current cost from a running container's costs.json.

--- a/cmd/horde/main_test.go
+++ b/cmd/horde/main_test.go
@@ -4888,3 +4888,58 @@ func TestAuditRelPath(t *testing.T) {
 		})
 	}
 }
+
+func TestParseEnvFlags(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		raw     []string
+		want    map[string]string
+		wantErr bool
+	}{
+		{"nil", nil, map[string]string{}, false},
+		{"empty", []string{}, map[string]string{}, false},
+		{"single", []string{"FOO=bar"}, map[string]string{"FOO": "bar"}, false},
+		{"multiple", []string{"FOO=bar", "BAZ=qux"}, map[string]string{"FOO": "bar", "BAZ": "qux"}, false},
+		{"empty value allowed", []string{"FOO="}, map[string]string{"FOO": ""}, false},
+		{"value with equals", []string{"DSN=a=b=c"}, map[string]string{"DSN": "a=b=c"}, false},
+		{"leading underscore key", []string{"_X=1"}, map[string]string{"_X": "1"}, false},
+		{"duplicate last wins", []string{"FOO=a", "FOO=b"}, map[string]string{"FOO": "b"}, false},
+		{"missing equals", []string{"FOO"}, nil, true},
+		{"empty key", []string{"=bar"}, nil, true},
+		{"key starts with digit", []string{"1FOO=bar"}, nil, true},
+		{"key with dash", []string{"FOO-BAR=baz"}, nil, true},
+		{"key with space", []string{"FOO BAR=baz"}, nil, true},
+		{"reserved REPO_URL", []string{"REPO_URL=x"}, nil, true},
+		{"reserved TICKET", []string{"TICKET=x"}, nil, true},
+		{"reserved BRANCH", []string{"BRANCH=x"}, nil, true},
+		{"reserved WORKFLOW", []string{"WORKFLOW=x"}, nil, true},
+		{"reserved RUN_ID", []string{"RUN_ID=x"}, nil, true},
+		{"reserved ARTIFACTS_BUCKET", []string{"ARTIFACTS_BUCKET=x"}, nil, true},
+		{"reserved ORC_EXTRA_ARGS", []string{"ORC_EXTRA_ARGS=x"}, nil, true},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseEnvFlags(tc.raw)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseEnvFlags(%v) = %v, want error", tc.raw, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseEnvFlags(%v) unexpected error: %v", tc.raw, err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("parseEnvFlags(%v) = %v, want %v", tc.raw, got, tc.want)
+			}
+			for k, v := range tc.want {
+				if got[k] != v {
+					t.Errorf("parseEnvFlags(%v)[%q] = %q, want %q", tc.raw, k, got[k], v)
+				}
+			}
+		})
+	}
+}

--- a/cmd/horde/main_test.go
+++ b/cmd/horde/main_test.go
@@ -4943,3 +4943,72 @@ func TestParseEnvFlags(t *testing.T) {
 		})
 	}
 }
+
+func TestSecretCollisionsOnECS(t *testing.T) {
+	t.Parallel()
+	// spec keyed by container env-var name; canonicals are always present in a
+	// real merged spec, plus a declared extra here.
+	spec := config.SecretSpec{
+		"CLAUDE_CODE_OAUTH_TOKEN": {},
+		"GIT_TOKEN":               {},
+		"STRIPE_API_KEY":          {},
+	}
+	tests := []struct {
+		name     string
+		provName string
+		extraEnv map[string]string
+		want     []string
+	}{
+		{
+			name:     "ecs collision with declared secret",
+			provName: config.ProviderECS,
+			extraEnv: map[string]string{"STRIPE_API_KEY": "sk_test"},
+			want:     []string{"STRIPE_API_KEY"},
+		},
+		{
+			name:     "ecs collision with canonical secret",
+			provName: config.ProviderECS,
+			extraEnv: map[string]string{"GIT_TOKEN": "x"},
+			want:     []string{"GIT_TOKEN"},
+		},
+		{
+			name:     "ecs non-secret key does not warn",
+			provName: config.ProviderECS,
+			extraEnv: map[string]string{"PROMPT_VARIANT": "v3"},
+			want:     nil,
+		},
+		{
+			name:     "ecs multiple collisions sorted",
+			provName: config.ProviderECS,
+			extraEnv: map[string]string{"STRIPE_API_KEY": "x", "GIT_TOKEN": "y", "NEW": "z"},
+			want:     []string{"GIT_TOKEN", "STRIPE_API_KEY"},
+		},
+		{
+			name:     "docker never warns even on collision",
+			provName: config.ProviderDocker,
+			extraEnv: map[string]string{"STRIPE_API_KEY": "x", "GIT_TOKEN": "y"},
+			want:     nil,
+		},
+		{
+			name:     "ecs no extra env",
+			provName: config.ProviderECS,
+			extraEnv: map[string]string{},
+			want:     nil,
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := secretCollisionsOnECS(tc.provName, spec, tc.extraEnv)
+			if len(got) != len(tc.want) {
+				t.Fatalf("secretCollisionsOnECS = %v, want %v", got, tc.want)
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Errorf("secretCollisionsOnECS[%d] = %q, want %q (full: %v)", i, got[i], tc.want[i], got)
+				}
+			}
+		})
+	}
+}

--- a/internal/docs/content.go
+++ b/internal/docs/content.go
@@ -238,6 +238,10 @@ Per-launch env vars (--env)
                  Overriding a non-secret key, and setting brand-new keys,
                  work the same on both providers.
 
+    --env applies to 'horde launch' only. Per-launch values are not stored
+    on the run record, so 'horde retry' does not carry them forward — pass
+    --env again on a fresh launch if a resumed run needs them.
+
 File Location
 -------------
 

--- a/internal/docs/content.go
+++ b/internal/docs/content.go
@@ -208,6 +208,36 @@ secrets (map, optional):
             env: STRIPE_API_KEY
             aws-secret: prepdesk/stripe-api-key
 
+Per-launch env vars (--env)
+---------------------------
+
+    Everything above is project-level: every run for a repo gets the same
+    set. For values that vary per launch — a feature flag, an experiment
+    variant, an orchestrator's run ID — pass --env KEY=VALUE on the launch.
+    The flag is repeatable:
+
+        horde launch PROJ-1 --workflow build \
+          --env PROMPT_VARIANT=v3 --env DEBUG=1
+
+    Keys must be valid env-var names ([A-Za-z_][A-Za-z0-9_]*). VALUE may be
+    empty (--env FLAG=) and may itself contain '='. On a duplicate key the
+    last --env wins. The horde-managed control vars (REPO_URL, TICKET,
+    BRANCH, WORKFLOW, RUN_ID, ARTIFACTS_BUCKET, ORC_EXTRA_ARGS) are reserved
+    and rejected.
+
+    Override of project secrets:
+
+        docker — a per-launch --env value overrides a project secret (or
+                 any .env value) of the same key. Use it to point one run at
+                 a staging key without editing .env.
+
+        ECS    — a declared secret of the same name takes precedence: the
+                 secret lives on the task definition and AWS wins over the
+                 RunTask environment override. horde injects the --env value
+                 anyway and prints a warning that it will not take effect.
+                 Overriding a non-secret key, and setting brand-new keys,
+                 work the same on both providers.
+
 File Location
 -------------
 

--- a/internal/docs/content.go
+++ b/internal/docs/content.go
@@ -111,6 +111,8 @@ const topicQuickstart = `Quick Start
 
 Other useful commands:
 
+    horde launch ... --env KEY=VALUE  # set a per-launch env var (repeatable;
+                                      # see 'horde docs config')
     horde kill <run-id>      # stop a running run
     horde retry <run-id>     # restart — orc picks up where it left off
     horde retry <run-id> -- --resume  # pass extra flags through to orc

--- a/internal/provider/docker.go
+++ b/internal/provider/docker.go
@@ -164,6 +164,19 @@ func (p *DockerProvider) Launch(ctx context.Context, opts LaunchOpts) (*LaunchRe
 			args = append(args, "-e", containerName)
 		}
 	}
+	// Per-launch env vars (horde launch --env KEY=VALUE). Appended AFTER
+	// --env-file so docker's later-wins semantics let them override a
+	// project secret of the same key. Sorted for deterministic argv.
+	if len(opts.ExtraEnv) > 0 {
+		keys := make([]string, 0, len(opts.ExtraEnv))
+		for k := range opts.ExtraEnv {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			args = append(args, "-e", k+"="+opts.ExtraEnv[k])
+		}
+	}
 	for _, mount := range allMounts {
 		args = append(args, "-v", mount)
 	}

--- a/internal/provider/docker_test.go
+++ b/internal/provider/docker_test.go
@@ -141,6 +141,66 @@ func TestDockerProvider_Launch_WithOrcArgs(t *testing.T) {
 	}
 }
 
+func TestDockerProvider_Launch_WithExtraEnv(t *testing.T) {
+	argsFile := filepath.Join(t.TempDir(), "args.txt")
+	containerID := strings.Repeat("e", 64)
+	dir := t.TempDir()
+	script := fmt.Sprintf("printf '%%s\\n' \"$@\" > %s\necho '%s'\n", argsFile, containerID)
+	writeFakeDocker(t, dir, script)
+	t.Setenv("PATH", dir+":"+os.Getenv("PATH"))
+
+	_, err := NewDockerProvider().Launch(context.Background(), LaunchOpts{
+		Repo: "r", Ticket: "T", Branch: "b", Workflow: "w", RunID: "id",
+		EnvFile:  "/secrets/.env",
+		ExtraEnv: map[string]string{"ZED": "last", "FOO": "bar=baz", "EMPTY": ""},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	raw, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("reading args file: %v", err)
+	}
+	args := strings.Split(strings.TrimSpace(string(raw)), "\n")
+	joined := strings.Join(args, " ")
+
+	for _, want := range []string{
+		"-e FOO=bar=baz",
+		"-e ZED=last",
+		"-e EMPTY=",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("args missing %q; got: %s", want, joined)
+		}
+	}
+
+	// Per-launch env must come AFTER --env-file so docker's later-wins
+	// semantics let it override an --env-file value of the same key.
+	envFileIdx := indexOf(args, "--env-file")
+	fooIdx := indexOf(args, "FOO=bar=baz")
+	if envFileIdx == -1 || fooIdx == -1 {
+		t.Fatalf("expected both --env-file and FOO=...; got: %v", args)
+	}
+	if fooIdx < envFileIdx {
+		t.Errorf("ExtraEnv FOO (idx %d) must come after --env-file (idx %d); got: %v", fooIdx, envFileIdx, args)
+	}
+
+	// Keys are emitted in sorted order for deterministic argv.
+	emptyIdx, fIdx, zIdx := indexOf(args, "EMPTY="), indexOf(args, "FOO=bar=baz"), indexOf(args, "ZED=last")
+	if !(emptyIdx < fIdx && fIdx < zIdx) {
+		t.Errorf("ExtraEnv keys not in sorted order: EMPTY=%d FOO=%d ZED=%d; got: %v", emptyIdx, fIdx, zIdx, args)
+	}
+}
+
+func indexOf(args []string, s string) int {
+	for i, a := range args {
+		if a == s {
+			return i
+		}
+	}
+	return -1
+}
+
 func TestDockerProvider_Launch_NoOrcArgs(t *testing.T) {
 	argsFile := filepath.Join(t.TempDir(), "args.txt")
 	dir := t.TempDir()

--- a/internal/provider/ecs.go
+++ b/internal/provider/ecs.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -147,6 +148,10 @@ func (p *ECSProvider) Launch(ctx context.Context, opts LaunchOpts) (*LaunchResul
 	// is set at deploy time by the bootstrap CF template / @horde.io/cdk
 	// construct. RunTask cannot add secrets per launch — only environment
 	// overrides — so opts.SecretEnvRemap is intentionally ignored on ECS.
+	// Per-launch opts.ExtraEnv IS passed (as environment overrides below),
+	// but for the same reason it cannot override a task-definition secret of
+	// the same name: AWS gives the secret precedence. main.go warns the user
+	// when an --env key collides with a declared secret on ECS.
 	// RUN_ID flows into the ECS tag and the S3 session/snapshot key prefixes
 	// the worker builds, so validate it before it leaves the CLI — even
 	// though retry reuses an already-validated stored ID, this guards any
@@ -171,6 +176,22 @@ func (p *ECSProvider) Launch(ctx context.Context, opts LaunchOpts) (*LaunchResul
 			Name:  aws.String("ORC_EXTRA_ARGS"),
 			Value: aws.String(strings.Join(opts.OrcArgs, " ")),
 		})
+	}
+	// Per-launch env vars (horde launch --env KEY=VALUE), as environment
+	// overrides. Sorted for deterministic ordering. See the secret-precedence
+	// caveat in the function-level comment above.
+	if len(opts.ExtraEnv) > 0 {
+		keys := make([]string, 0, len(opts.ExtraEnv))
+		for k := range opts.ExtraEnv {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			env = append(env, ecstypes.KeyValuePair{
+				Name:  aws.String(k),
+				Value: aws.String(opts.ExtraEnv[k]),
+			})
+		}
 	}
 
 	input := &ecs.RunTaskInput{

--- a/internal/provider/ecs_test.go
+++ b/internal/provider/ecs_test.go
@@ -285,6 +285,47 @@ func TestECSProvider_Launch_Success(t *testing.T) {
 	}
 }
 
+func TestECSProvider_Launch_WithExtraEnv(t *testing.T) {
+	t.Parallel()
+	fake := &fakeECSClient{
+		runTaskOutput: &ecs.RunTaskOutput{
+			Tasks: []ecstypes.Task{
+				{TaskArn: aws.String("arn:aws:ecs:us-east-1:123456789012:task/horde/abc")},
+			},
+		},
+	}
+	p := NewECSProvider(fake, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	opts := LaunchOpts{
+		Repo:     "github.com/org/repo.git",
+		Ticket:   "PROJ-1",
+		Branch:   "main",
+		Workflow: "default",
+		RunID:    "k7m2xp4qr9n3",
+		ExtraEnv: map[string]string{"PROMPT_VARIANT": "v3", "EMPTY": ""},
+	}
+	if _, err := p.Launch(context.Background(), opts); err != nil {
+		t.Fatalf("Launch() error = %v, want nil", err)
+	}
+	in := fake.runTaskInput
+	if in == nil {
+		t.Fatal("RunTask was not called")
+	}
+	envMap := make(map[string]string)
+	for _, kv := range in.Overrides.ContainerOverrides[0].Environment {
+		envMap[*kv.Name] = *kv.Value
+	}
+	if v, ok := envMap["PROMPT_VARIANT"]; !ok || v != "v3" {
+		t.Errorf("env[PROMPT_VARIANT] = %q (present=%v), want %q", v, ok, "v3")
+	}
+	if v, ok := envMap["EMPTY"]; !ok || v != "" {
+		t.Errorf("env[EMPTY] = %q (present=%v), want empty string present", v, ok)
+	}
+	// Canonical run params must still be present alongside per-launch vars.
+	if envMap["RUN_ID"] != "k7m2xp4qr9n3" {
+		t.Errorf("env[RUN_ID] = %q, want %q", envMap["RUN_ID"], "k7m2xp4qr9n3")
+	}
+}
+
 func TestECSProvider_Launch_RunTaskError(t *testing.T) {
 	t.Parallel()
 	fake := &fakeECSClient{runTaskErr: fmt.Errorf("AccessDeniedException: not authorized")}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -56,6 +56,14 @@ type LaunchOpts struct {
 	// host-name) and the two canonical secrets are already covered by
 	// --env-file and need not appear here.
 	SecretEnvRemap map[string]string
+
+	// ExtraEnv holds per-launch env vars (horde launch --env KEY=VALUE).
+	// Injected into the container alongside the project's standard set. On
+	// docker they override --env-file values of the same key (later -e wins).
+	// On ECS they cannot override a task-definition secret of the same name —
+	// AWS gives the secret precedence — so main.go warns on that collision.
+	// (issue #22)
+	ExtraEnv map[string]string
 }
 
 // ValidateRunID rejects empty run IDs and IDs that would enable path

--- a/test/integration/harness_common_test.go
+++ b/test/integration/harness_common_test.go
@@ -160,6 +160,13 @@ func (h *harness) Launch(ticket, workflow string, timeout time.Duration) string 
 // out (empty = provider default). ECS resume tests use this to run workflows
 // that only exist on the feature branch, not yet on origin's default branch.
 func (h *harness) LaunchBranch(ticket, workflow, branch string, timeout time.Duration) string {
+	return h.launchWith(ticket, workflow, branch, nil, timeout)
+}
+
+// launchWith is the general launch path: extraArgs are inserted before the
+// positional ticket (e.g. []string{"--env", "FOO=bar"}). Launch/LaunchBranch
+// delegate here with nil extraArgs.
+func (h *harness) launchWith(ticket, workflow, branch string, extraArgs []string, timeout time.Duration) string {
 	h.t.Helper()
 	args := append(h.providerArgs(), "launch", "--timeout", timeout.String())
 	if workflow != "" {
@@ -168,6 +175,7 @@ func (h *harness) LaunchBranch(ticket, workflow, branch string, timeout time.Dur
 	if branch != "" {
 		args = append(args, "--branch", branch)
 	}
+	args = append(args, extraArgs...)
 	args = append(args, ticket)
 	out, err := h.runHorde(args...)
 	if err != nil {

--- a/test/integration/secrets_test.go
+++ b/test/integration/secrets_test.go
@@ -107,6 +107,59 @@ func TestLaunchExtraSecretInjected(t *testing.T) {
 	// host name is not part of the secret-isolation guarantee.
 }
 
+// TestLaunchPerLaunchEnvInjectedAndOverrides verifies the issue #22 feature on
+// docker: a brand-new --env key reaches the container, and a --env value for a
+// key that also exists in .env overrides the .env value (docker: later -e wins
+// over --env-file).
+func TestLaunchPerLaunchEnvInjectedAndOverrides(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	h := newHarness(t)
+
+	// .env sets PROMPT_VARIANT=from-env; the launch overrides it. NEW_FLAG is
+	// not in .env or any config — it should appear purely from --env.
+	envContent := "CLAUDE_CODE_OAUTH_TOKEN=test-token\n" +
+		"GIT_TOKEN=test-token\n" +
+		"PROMPT_VARIANT=from-env\n"
+	if err := os.WriteFile(filepath.Join(h.workDir, ".env"), []byte(envContent), 0o644); err != nil {
+		t.Fatalf("writing .env: %v", err)
+	}
+
+	runID := h.launchWith("TEST-perlaunch-env", "env-dump", "",
+		[]string{"--env", "PROMPT_VARIANT=from-launch", "--env", "NEW_FLAG=on"},
+		1*time.Minute)
+	h.WaitForOrc(runID, 1*time.Minute)
+
+	envDumpPath := filepath.Join(h.WorkspaceDir(runID), ".orc", "artifacts", "TEST-perlaunch-env", "env-dump.txt")
+	deadline := time.Now().Add(15 * time.Second)
+	var dump string
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(envDumpPath)
+		if err == nil {
+			dump = string(data)
+			break
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	if dump == "" {
+		t.Fatalf("env-dump.txt not produced at %s", envDumpPath)
+	}
+
+	// New key injected purely via --env.
+	if !strings.Contains(dump, "NEW_FLAG=on") {
+		t.Errorf("env dump missing NEW_FLAG=on; dump:\n%s", dump)
+	}
+	// Override: --env beats the .env value of the same key.
+	if !strings.Contains(dump, "PROMPT_VARIANT=from-launch") {
+		t.Errorf("env dump missing overridden PROMPT_VARIANT=from-launch; dump:\n%s", dump)
+	}
+	if strings.Contains(dump, "PROMPT_VARIANT=from-env") {
+		t.Errorf("env dump still shows un-overridden PROMPT_VARIANT=from-env; dump:\n%s", dump)
+	}
+}
+
 // TestLaunchSecretMissingFromEnvFails asserts that horde refuses to launch
 // when .horde/config.yaml declares a docker secret whose env: source is
 // not present in .env.


### PR DESCRIPTION
Closes #22.

## What

Adds a repeatable `--env KEY=VALUE` flag (alias `-e`) to `horde launch` that injects per-launch environment variables into the run's container, alongside the project's standard set. Both new keys and overrides of project secrets are supported, threaded through both providers via a new `LaunchOpts.ExtraEnv map[string]string` field (mirroring the existing `OrcArgs` → `ORC_EXTRA_ARGS` pattern).

```bash
horde launch PROJ-1 --workflow build --env PROMPT_VARIANT=v3 --env DEBUG=1
```

`parseEnvFlags` validates keys (`[A-Za-z_][A-Za-z0-9_]*`), rejects the horde-managed control vars (`REPO_URL`, `TICKET`, `BRANCH`, `WORKFLOW`, `RUN_ID`, `ARTIFACTS_BUCKET`, `ORC_EXTRA_ARGS`), allows empty values and values containing `=`, and applies last-wins on duplicate keys.

## Override semantics (the one cross-provider asymmetry)

- **docker** — `-e` is appended *after* `--env-file`, so docker's later-wins makes a per-launch value override a project secret of the same key.
- **ECS** — values are passed as RunTask `environment` overrides. AWS gives task-definition `secrets:` precedence over those overrides, so a per-launch `--env` **cannot** override a *declared secret* on ECS. We inject it anyway and print a warning rather than failing. New keys and non-secret overrides work the same on both providers.

`--env` applies to `launch` only — values aren't persisted on the run record, so `horde retry` does not carry them forward (documented in the flag usage and `horde docs config`).

## Tests

- `parseEnvFlags` table test (every edge + reserved key)
- `secretCollisionsOnECS` test (warning fires on ECS+declared/canonical secret; silent for non-secret keys; silent on docker)
- docker provider arg-capture: presence, after-`--env-file` ordering, sorted determinism, empty/`=`-containing values
- ECS provider: per-launch pairs land on the container override alongside canonical env
- integration (real Docker): a new key reaches the container and `--env` overrides a `.env` value of the same key

`make build` / `make vet` / `make unit-test` / `make integration-test` all pass.

## Review

Ran a deep multi-agent review (3 independent reviewers across provider, CLI, and test-coverage dimensions). It surfaced one blocking gap (the ECS warning branch was untested) and two doc gaps (retry behavior, SPEC synopsis) — all addressed in the second commit. No correctness defects were found in the implementation.

## Docs

- New "Per-launch env vars (--env)" section in `horde docs config`
- `SPEC.md` launch synopsis + `README.md` launch examples updated