### PR TITLE
cdk: sidecar containers in the worker task definition (#7)

### DIFF
--- a/.orc/workflows/postgres-probe.yaml
+++ b/.orc/workflows/postgres-probe.yaml
@@ -1,0 +1,24 @@
+name: horde-test
+ticket-pattern: 'TEST-[\w-]+'
+# Probes a Postgres sidecar on localhost:5432 to prove sidecar support (#7):
+# the worker shares the task's network namespace and reaches the sidecar on
+# localhost. Uses bash's /dev/tcp so no postgres client is needed in the image.
+# Retries because the sidecar may still be starting. Exits 0 on reach, 1 if the
+# sidecar never comes up within the window.
+phases:
+  - name: run
+    type: script
+    run: |
+      set -u
+      for i in $(seq 1 30); do
+        if (exec 3<>/dev/tcp/localhost/5432) 2>/dev/null; then
+          exec 3>&- 2>/dev/null || true
+          echo "postgres-probe: reached localhost:5432 on attempt $i"
+          exit 0
+        fi
+        echo "postgres-probe: attempt $i — localhost:5432 not ready, retrying"
+        sleep 2
+      done
+      echo "postgres-probe: localhost:5432 never became reachable" >&2
+      exit 1
+    timeout: 3

--- a/cdk/README.md
+++ b/cdk/README.md
@@ -46,6 +46,50 @@ writing or querying run records, so every CI runner and dev box launching
 against this stack writes to the same `by-repo` bucket — no drift from local
 git remote variations (with vs. without `.git`, https vs. ssh).
 
+## Sidecar containers
+
+Some projects need an auxiliary service alongside the worker for the duration of
+a run — a test database, a headless browser server, a mock API. The `sidecars`
+prop adds extra containers to the worker's Fargate task definition. They share
+the task's network namespace, so the worker reaches them on `localhost`, and
+they start and stop with it.
+
+```ts
+new HordeWorker(stack, "Horde", {
+  // ...required props...
+  memoryMiB: 4096, // task ceiling, shared across all containers
+  sidecars: [
+    {
+      containerName: "postgres",
+      image: ecs.ContainerImage.fromRegistry("postgres:16"),
+      environment: { POSTGRES_PASSWORD: "dev" },
+      memoryLimitMiB: 1024, // optional per-container cap
+      // essential defaults to false — a crashing sidecar won't stop the run
+    },
+  ],
+});
+```
+
+Each entry is a standard CDK
+[`ContainerDefinitionOptions`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecs.ContainerDefinitionOptions.html),
+so `healthCheck`, `portMappings`, `secrets`, `command`, and `dependsOn` are all
+available. The construct fills in two defaults when you omit them (your explicit
+value always wins):
+
+- **`essential: false`** — a crashing sidecar does not fail the run. Set
+  `essential: true` for a hard dependency (e.g. a database the worker can't run
+  without), so the task fails fast if it can't start.
+- **`logging`** — routed to the worker's CloudWatch log group with the
+  sidecar's `containerName` as the stream prefix.
+
+Run status always reflects the **worker** container's exit code, never a
+sidecar's — even an essential sidecar that exits non-zero. `memoryMiB` sizes the
+whole task; sidecars share that ceiling unless you set a per-container
+`memoryLimitMiB`. The name `horde-worker` is reserved and rejected at synth time.
+
+> Sidecars are a CDK-construct feature. The `horde bootstrap` (CloudFormation)
+> path and the local `--provider docker` runner do not provision sidecars.
+
 ## Development
 
 ```bash

--- a/cdk/e2e/app.ts
+++ b/cdk/e2e/app.ts
@@ -75,6 +75,21 @@ const worker = new HordeWorker(stack, "Worker", {
   // to 20 to match the bootstrap CF stack's e2e budget. Production
   // consumers are expected to tune this per their own load.
   maxConcurrent: 20,
+  // Sidecar containers (#7). A Postgres the worker reaches on localhost:5432.
+  // TestECSCDK_Sidecar launches the `postgres-probe` workflow against this to
+  // prove (a) localhost reachability and (b) that run status is the WORKER's
+  // exit code, not this non-essential sidecar's (it is killed non-zero when the
+  // worker exits). essential is left at the construct default (false).
+  sidecars: [
+    {
+      containerName: "postgres",
+      image: ecs.ContainerImage.fromRegistry("public.ecr.aws/docker/library/postgres:16-alpine"),
+      environment: { POSTGRES_HOST_AUTH_METHOD: "trust" },
+      // Small cap so the sidecar can't starve the worker (memoryMiB is the
+      // task ceiling shared across containers).
+      memoryLimitMiB: 512,
+    },
+  ],
 });
 
 new cdk.CfnOutput(stack, "StackNameOut", { value: stack.stackName });

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@horde.io/cdk",
-  "version": "0.1.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@horde.io/cdk",
-      "version": "0.1.0",
+      "version": "0.4.0",
       "license": "MIT",
       "devDependencies": {
         "@aws-sdk/client-dynamodb": "^3.600.0",

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@horde.io/cdk",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "AWS CDK construct that provisions the infrastructure required by horde (https://github.com/jorge-barreto/horde): ECS Fargate cluster, DynamoDB runs table, S3 artifacts bucket, SSM config parameter, EventBridge status sync, and scoped IAM.",
   "license": "MIT",
   "repository": {

--- a/cdk/src/horde-worker-props.ts
+++ b/cdk/src/horde-worker-props.ts
@@ -1,5 +1,5 @@
 import type { IVpc } from "aws-cdk-lib/aws-ec2";
-import type { ContainerImage } from "aws-cdk-lib/aws-ecs";
+import type { ContainerDefinitionOptions, ContainerImage } from "aws-cdk-lib/aws-ecs";
 import type { IRepository } from "aws-cdk-lib/aws-ecr";
 import type { IBucket } from "aws-cdk-lib/aws-s3";
 import type { ISecret } from "aws-cdk-lib/aws-secretsmanager";
@@ -120,4 +120,31 @@ export interface HordeWorkerProps {
    *   CLI is pointed at.
    */
   readonly ssmParameterPath?: string;
+
+  /**
+   * Extra containers added to the worker's Fargate task definition. They share
+   * the task's network namespace — so the worker reaches them on `localhost` —
+   * and the task's lifecycle, starting and stopping with it. Typical uses: a
+   * Postgres/Redis the test suite hits on localhost, a headless
+   * Playwright/Selenium server, or a Stripe/LocalStack mock.
+   *
+   * Each entry is passed to `taskDefinition.addContainer()` with two defaults
+   * the construct fills in when you omit them (your explicit value always wins):
+   *
+   *  - `essential: false` — a crashing sidecar does NOT stop the run. Set
+   *    `essential: true` for a dependency the worker cannot run without (e.g. a
+   *    database), so the task fails fast if it can't start. The worker container
+   *    is always `essential: true`; run status is derived from the worker's exit
+   *    code, never a sidecar's, regardless of `essential`.
+   *  - `logging` — routed to the worker's CloudWatch log group with the
+   *    sidecar's `containerName` as the stream prefix, so sidecar output is
+   *    captured alongside the worker by default.
+   *
+   * `memoryMiB` sizes the whole task; sidecars share that ceiling unless you set
+   * a per-container `memoryLimitMiB`. The container name `"horde-worker"` is
+   * reserved for the worker and rejected at synth time.
+   *
+   * @default — none; a single-container task definition.
+   */
+  readonly sidecars?: ContainerDefinitionOptions[];
 }

--- a/cdk/src/horde-worker.ts
+++ b/cdk/src/horde-worker.ts
@@ -338,8 +338,10 @@ export class HordeWorker extends Construct {
     // Sidecars are added AFTER the worker, so the worker is container index 0
     // (defensive — the status Lambda finds the worker by name, not by index).
     // Defaults: essential:false so a crashing sidecar doesn't stop the run, and
-    // logging routed to the worker log group keyed by the sidecar name. The
-    // caller's explicit values win (spread last).
+    // logging routed to the worker log group keyed by the sidecar name. Applied
+    // with `??` (not spread order) so an explicit `essential: undefined` from a
+    // caller can't fall through to CDK's own `essential: true` default and
+    // silently flip a sidecar to essential / drop its logging.
     this.sidecarContainers = (props.sidecars ?? []).map((sidecar, i) => {
       if (sidecar.containerName === WORKER_CONTAINER_NAME) {
         throw new Error(
@@ -349,12 +351,14 @@ export class HordeWorker extends Construct {
       }
       const id = sidecar.containerName ?? `Sidecar${i}`;
       return this.taskDefinition.addContainer(id, {
-        essential: false,
-        logging: ecs.LogDriver.awsLogs({
-          logGroup: this.logGroup,
-          streamPrefix: sidecar.containerName ?? `sidecar${i}`,
-        }),
         ...sidecar,
+        essential: sidecar.essential ?? false,
+        logging:
+          sidecar.logging ??
+          ecs.LogDriver.awsLogs({
+            logGroup: this.logGroup,
+            streamPrefix: sidecar.containerName ?? `sidecar${i}`,
+          }),
       });
     });
 

--- a/cdk/src/horde-worker.ts
+++ b/cdk/src/horde-worker.ts
@@ -14,6 +14,18 @@ import * as path from "path";
 
 import type { HordeWorkerProps } from "./horde-worker-props";
 
+/**
+ * Name of the worker container in the Fargate task definition. The status-sync
+ * Lambda derives run status from THIS container's exit code (never a sidecar's),
+ * and the horde CLI's ECS provider uses it to build the CloudWatch log-stream
+ * path and target env overrides at launch. It is therefore a cross-language
+ * contract — not a configurable prop. Three other places must stay equal to it:
+ * the standalone copy in `./status-lambda/index.ts`, `const containerName` in
+ * `internal/provider/ecs.go`, and the container `Name` in
+ * `internal/bootstrap/templates/stack.yaml.tmpl`.
+ */
+export const WORKER_CONTAINER_NAME = "horde-worker";
+
 const RETENTION_DAYS: ReadonlyMap<number, logs.RetentionDays> = new Map([
   [1, logs.RetentionDays.ONE_DAY],
   [3, logs.RetentionDays.THREE_DAYS],
@@ -97,6 +109,12 @@ export class HordeWorker extends Construct {
 
   /** The worker container inside `taskDefinition`. */
   public readonly container: ecs.ContainerDefinition;
+
+  /**
+   * Caller-defined sidecar containers added to `taskDefinition`, in declaration
+   * order. Empty when `props.sidecars` is unset. See `HordeWorkerProps.sidecars`.
+   */
+  public readonly sidecarContainers: ecs.ContainerDefinition[];
 
   /**
    * S3 bucket holding run artifacts (logs, run-result.json) under
@@ -306,7 +324,7 @@ export class HordeWorker extends Construct {
       taskDefSecrets[envName] = ecs.Secret.fromSecretsManager(isecret);
     }
     this.container = this.taskDefinition.addContainer("worker", {
-      containerName: "horde-worker",
+      containerName: WORKER_CONTAINER_NAME,
       image: props.workerImage,
       essential: true,
       stopTimeout: cdk.Duration.seconds(120),
@@ -315,6 +333,29 @@ export class HordeWorker extends Construct {
         streamPrefix: "ecs",
       }),
       secrets: taskDefSecrets,
+    });
+
+    // Sidecars are added AFTER the worker, so the worker is container index 0
+    // (defensive — the status Lambda finds the worker by name, not by index).
+    // Defaults: essential:false so a crashing sidecar doesn't stop the run, and
+    // logging routed to the worker log group keyed by the sidecar name. The
+    // caller's explicit values win (spread last).
+    this.sidecarContainers = (props.sidecars ?? []).map((sidecar, i) => {
+      if (sidecar.containerName === WORKER_CONTAINER_NAME) {
+        throw new Error(
+          `HordeWorker: sidecar containerName "${WORKER_CONTAINER_NAME}" is ` +
+            `reserved for the worker container.`,
+        );
+      }
+      const id = sidecar.containerName ?? `Sidecar${i}`;
+      return this.taskDefinition.addContainer(id, {
+        essential: false,
+        logging: ecs.LogDriver.awsLogs({
+          logGroup: this.logGroup,
+          streamPrefix: sidecar.containerName ?? `sidecar${i}`,
+        }),
+        ...sidecar,
+      });
     });
 
     // SSM config parameter consumed by the horde CLI. JSON keys must match

--- a/cdk/src/index.ts
+++ b/cdk/src/index.ts
@@ -1,2 +1,2 @@
-export { HordeWorker } from "./horde-worker";
+export { HordeWorker, WORKER_CONTAINER_NAME } from "./horde-worker";
 export type { HordeWorkerProps, HordeWorkerSecrets } from "./horde-worker-props";

--- a/cdk/src/status-lambda/index.test.ts
+++ b/cdk/src/status-lambda/index.test.ts
@@ -389,6 +389,43 @@ describe("status-lambda handler (5fh.16)", () => {
     expect(input.ExpressionAttributeValues?.[":ca"]).toEqual({ NULL: true });
   });
 
+  it("reads the worker container's exit code regardless of array order (sidecars)", async () => {
+    // With sidecars in the task def, the ECS event's `containers` array order
+    // is not guaranteed. A sidecar that exits non-zero must NOT be read as the
+    // run's status — the handler must find the container named "horde-worker".
+    ddbMock.on(QueryCommand).resolves({ Items: [{ id: { S: "run-sc" } }] });
+    ddbMock.on(UpdateItemCommand).resolves({});
+    s3Mock.on(ListObjectsV2Command).resolves({ Contents: [] });
+
+    const r = await handler(
+      event({
+        lastStatus: "STOPPED",
+        taskArn: "arn:task/sc",
+        containers: [
+          { exitCode: 137, name: "postgres" }, // sidecar killed when task stops
+          { exitCode: 0, name: "horde-worker" }, // worker succeeded
+        ],
+      }),
+      ctx,
+      () => {},
+    );
+
+    expect(r).toEqual({ updated: true, runId: "run-sc", status: "success", exitCode: 0 });
+  });
+
+  it("falls back to the first container when none is named horde-worker (legacy single-container events)", async () => {
+    ddbMock.on(QueryCommand).resolves({ Items: [{ id: { S: "run-legacy" } }] });
+    ddbMock.on(UpdateItemCommand).resolves({});
+    s3Mock.on(ListObjectsV2Command).resolves({ Contents: [] });
+
+    const r = await handler(
+      event({ lastStatus: "STOPPED", taskArn: "arn:task/legacy", containers: [{ exitCode: 0 }] }),
+      ctx,
+      () => {},
+    );
+    expect(r).toEqual({ updated: true, runId: "run-legacy", status: "success", exitCode: 0 });
+  });
+
   it("queries the by-instance GSI with the task ARN as instance_id", async () => {
     ddbMock.on(QueryCommand).resolves({ Items: [{ id: { S: "run-q" } }] });
     ddbMock.on(UpdateItemCommand).resolves({});

--- a/cdk/src/status-lambda/index.ts
+++ b/cdk/src/status-lambda/index.ts
@@ -33,6 +33,13 @@ import {
 const RUNS_TABLE = process.env.RUNS_TABLE ?? "";
 const ARTIFACTS_BUCKET = process.env.ARTIFACTS_BUCKET ?? "";
 
+// The worker container's name in the task definition. Run status is derived
+// from THIS container's exit code, never a sidecar's. Must stay equal to
+// WORKER_CONTAINER_NAME in ../horde-worker.ts — this Lambda is esbuild-bundled
+// standalone and cannot import construct code, so it keeps its own copy. The
+// Python lambda in internal/bootstrap/templates/stack.yaml.tmpl mirrors this.
+const WORKER_CONTAINER_NAME = "horde-worker";
+
 const ddb = new DynamoDBClient({});
 const s3 = new S3Client({});
 
@@ -148,11 +155,15 @@ export const handler: Handler<
     return { skipped: "task not managed by horde" };
   }
 
+  // Status is the WORKER container's exit code, not the task's. With sidecars
+  // in the task def the event's `containers` order is not guaranteed, so find
+  // the worker by name; fall back to the first container for legacy
+  // single-container events that may omit the name field.
   const containers = detail.containers ?? [];
+  const worker =
+    containers.find((c) => c.name === WORKER_CONTAINER_NAME) ?? containers[0];
   const exitCode =
-    containers.length > 0 && typeof containers[0].exitCode === "number"
-      ? containers[0].exitCode
-      : null;
+    worker && typeof worker.exitCode === "number" ? worker.exitCode : null;
   const status = mapStatus(exitCode);
 
   const stoppedAt = detail.stoppedAt;

--- a/cdk/test/__snapshots__/horde-worker-matrix.test.ts.snap
+++ b/cdk/test/__snapshots__/horde-worker-matrix.test.ts.snap
@@ -815,7 +815,7 @@ exports[`HordeWorker matrix — default (no vpc, no bucket) matches the saved sn
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-111111111111-us-east-1",
-          "S3Key": "cf4ad587c39f1c95642883b0a4d762a2438b4b8e5869a43e25f95110b3a069de.zip",
+          "S3Key": "c11cae0017e53f1be66ebd8cda44518d6b53187edd7a85660bb227f4ad2fdcbc.zip",
         },
         "Environment": {
           "Variables": {
@@ -2139,7 +2139,7 @@ exports[`HordeWorker matrix — provided bucket matches the saved snapshot 1`] =
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-111111111111-us-east-1",
-          "S3Key": "cf4ad587c39f1c95642883b0a4d762a2438b4b8e5869a43e25f95110b3a069de.zip",
+          "S3Key": "c11cae0017e53f1be66ebd8cda44518d6b53187edd7a85660bb227f4ad2fdcbc.zip",
         },
         "Environment": {
           "Variables": {
@@ -3471,7 +3471,7 @@ exports[`HordeWorker matrix — provided vpc and bucket matches the saved snapsh
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-111111111111-us-east-1",
-          "S3Key": "cf4ad587c39f1c95642883b0a4d762a2438b4b8e5869a43e25f95110b3a069de.zip",
+          "S3Key": "c11cae0017e53f1be66ebd8cda44518d6b53187edd7a85660bb227f4ad2fdcbc.zip",
         },
         "Environment": {
           "Variables": {
@@ -5007,7 +5007,7 @@ exports[`HordeWorker matrix — provided vpc matches the saved snapshot 1`] = `
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-111111111111-us-east-1",
-          "S3Key": "cf4ad587c39f1c95642883b0a4d762a2438b4b8e5869a43e25f95110b3a069de.zip",
+          "S3Key": "c11cae0017e53f1be66ebd8cda44518d6b53187edd7a85660bb227f4ad2fdcbc.zip",
         },
         "Environment": {
           "Variables": {

--- a/cdk/test/__snapshots__/horde-worker.test.ts.snap
+++ b/cdk/test/__snapshots__/horde-worker.test.ts.snap
@@ -815,7 +815,7 @@ exports[`HordeWorker (5fh.3 skeleton) matches the saved snapshot 1`] = `
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-111111111111-us-east-1",
-          "S3Key": "cf4ad587c39f1c95642883b0a4d762a2438b4b8e5869a43e25f95110b3a069de.zip",
+          "S3Key": "c11cae0017e53f1be66ebd8cda44518d6b53187edd7a85660bb227f4ad2fdcbc.zip",
         },
         "Environment": {
           "Variables": {

--- a/cdk/test/horde-worker-sidecars.test.ts
+++ b/cdk/test/horde-worker-sidecars.test.ts
@@ -1,0 +1,143 @@
+// Tests for the `sidecars` prop (issue #7): additional containers added to the
+// worker's Fargate task definition. Verifies the construct's defaults
+// (essential:false, shared-log-group logging), that caller values win, the
+// reserved-name guard, and that the worker container is never displaced.
+import { App, Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import * as ecr from "aws-cdk-lib/aws-ecr";
+import * as ecs from "aws-cdk-lib/aws-ecs";
+import * as secretsmanager from "aws-cdk-lib/aws-secretsmanager";
+import { HordeWorker, WORKER_CONTAINER_NAME, type HordeWorkerProps } from "../src";
+
+const ENV = { account: "111111111111", region: "us-east-1" };
+
+function synthWith(sidecars: HordeWorkerProps["sidecars"]): Template {
+  const app = new App();
+  const stack = new Stack(app, "TestStack", { env: ENV });
+  const repo = ecr.Repository.fromRepositoryName(stack, "Repo", "horde-test");
+  new HordeWorker(stack, "Horde", {
+    projectSlug: "test",
+    repo: "github.com/example/test",
+    workerImage: ecs.ContainerImage.fromRegistry("public.ecr.aws/horde/test:latest"),
+    ecrRepository: repo,
+    secrets: {
+      CLAUDE_CODE_OAUTH_TOKEN: secretsmanager.Secret.fromSecretNameV2(stack, "Claude", "horde/claude"),
+      GIT_TOKEN: secretsmanager.Secret.fromSecretNameV2(stack, "Git", "horde/git"),
+    },
+    sidecars,
+  });
+  return Template.fromStack(stack);
+}
+
+function buildWith(sidecars: HordeWorkerProps["sidecars"]): HordeWorker {
+  const app = new App();
+  const stack = new Stack(app, "TestStack", { env: ENV });
+  const repo = ecr.Repository.fromRepositoryName(stack, "Repo", "horde-test");
+  return new HordeWorker(stack, "Horde", {
+    projectSlug: "test",
+    repo: "github.com/example/test",
+    workerImage: ecs.ContainerImage.fromRegistry("public.ecr.aws/horde/test:latest"),
+    ecrRepository: repo,
+    secrets: {
+      CLAUDE_CODE_OAUTH_TOKEN: secretsmanager.Secret.fromSecretNameV2(stack, "Claude", "horde/claude"),
+      GIT_TOKEN: secretsmanager.Secret.fromSecretNameV2(stack, "Git", "horde/git"),
+    },
+    sidecars,
+  });
+}
+
+describe("HordeWorker sidecars (#7)", () => {
+  it("adds a sidecar as a second container in the task definition", () => {
+    const t = synthWith([
+      { containerName: "postgres", image: ecs.ContainerImage.fromRegistry("postgres:16") },
+    ]);
+    const tds = t.findResources("AWS::ECS::TaskDefinition");
+    const td = Object.values(tds)[0];
+    const names = (td.Properties.ContainerDefinitions ?? []).map((c: { Name: string }) => c.Name);
+    expect(names).toContain(WORKER_CONTAINER_NAME);
+    expect(names).toContain("postgres");
+    expect(names).toHaveLength(2);
+  });
+
+  it("defaults a sidecar to Essential: false; worker stays Essential: true", () => {
+    const t = synthWith([
+      { containerName: "postgres", image: ecs.ContainerImage.fromRegistry("postgres:16") },
+    ]);
+    t.hasResourceProperties("AWS::ECS::TaskDefinition", {
+      ContainerDefinitions: Match.arrayWith([
+        Match.objectLike({ Name: WORKER_CONTAINER_NAME, Essential: true }),
+        Match.objectLike({ Name: "postgres", Essential: false }),
+      ]),
+    });
+  });
+
+  it("honors an explicit Essential: true on a sidecar", () => {
+    const t = synthWith([
+      {
+        containerName: "postgres",
+        image: ecs.ContainerImage.fromRegistry("postgres:16"),
+        essential: true,
+      },
+    ]);
+    t.hasResourceProperties("AWS::ECS::TaskDefinition", {
+      ContainerDefinitions: Match.arrayWith([
+        Match.objectLike({ Name: "postgres", Essential: true }),
+      ]),
+    });
+  });
+
+  it("defaults sidecar logging to the worker log group with its name as the stream prefix", () => {
+    const t = synthWith([
+      { containerName: "postgres", image: ecs.ContainerImage.fromRegistry("postgres:16") },
+    ]);
+    t.hasResourceProperties("AWS::ECS::TaskDefinition", {
+      ContainerDefinitions: Match.arrayWith([
+        Match.objectLike({
+          Name: "postgres",
+          LogConfiguration: Match.objectLike({
+            LogDriver: "awslogs",
+            Options: Match.objectLike({ "awslogs-stream-prefix": "postgres" }),
+          }),
+        }),
+      ]),
+    });
+  });
+
+  it("rejects a sidecar that reuses the reserved worker container name", () => {
+    expect(() =>
+      buildWith([
+        { containerName: WORKER_CONTAINER_NAME, image: ecs.ContainerImage.fromRegistry("x:1") },
+      ]),
+    ).toThrow(/reserved/);
+  });
+
+  it("exposes the added sidecar containers via sidecarContainers", () => {
+    const worker = buildWith([
+      { containerName: "postgres", image: ecs.ContainerImage.fromRegistry("postgres:16") },
+      { containerName: "redis", image: ecs.ContainerImage.fromRegistry("redis:7") },
+    ]);
+    expect(worker.sidecarContainers).toHaveLength(2);
+    expect(worker.sidecarContainers.map((c) => c.containerName)).toEqual(["postgres", "redis"]);
+  });
+
+  it("creates a single-container task definition when no sidecars are given", () => {
+    const t = synthWith(undefined);
+    const td = Object.values(t.findResources("AWS::ECS::TaskDefinition"))[0];
+    expect(td.Properties.ContainerDefinitions).toHaveLength(1);
+  });
+});
+
+describe("worker container name (lockstep with Go provider + Python Lambda)", () => {
+  it("synthesizes the worker container with Name equal to WORKER_CONTAINER_NAME", () => {
+    const t = synthWith(undefined);
+    t.hasResourceProperties("AWS::ECS::TaskDefinition", {
+      ContainerDefinitions: Match.arrayWith([
+        Match.objectLike({ Name: WORKER_CONTAINER_NAME }),
+      ]),
+    });
+    // Guards against an accidental rename that would silently break the
+    // status-Lambda filter, the Go ECS provider's log-stream path, and the
+    // bootstrap CFN template — all of which hardcode this string.
+    expect(WORKER_CONTAINER_NAME).toBe("horde-worker");
+  });
+});

--- a/docs/superpowers/specs/2026-06-08-sidecar-containers-design.md
+++ b/docs/superpowers/specs/2026-06-08-sidecar-containers-design.md
@@ -93,8 +93,11 @@ this.sidecarContainers = (props.sidecars ?? []).map((s) => {
 });
 ```
 
-The merge spreads `s` last so a caller-provided `essential`/`logging` wins over
-the defaults; the snippet is illustrative of intent, not final code. Expose
+Defaults are applied with `essential: s.essential ?? false` and
+`logging: s.logging ?? <shared-group>` — NOT by spreading `s` last — so a caller
+passing an explicit `essential: undefined` can't fall through to CDK's own
+`essential: true` default and silently flip a sidecar to essential. The snippet
+is illustrative of intent, not final code. Expose
 `public readonly sidecarContainers: ecs.ContainerDefinition[]`.
 
 The worker container is still added first (defensive), but correctness no longer
@@ -157,6 +160,19 @@ exit_code = worker.get("exitCode") if worker else None
 This is a no-op for current single-container stacks and future-proofs the
 bootstrap path if it ever gains a sidecar.
 
+**The third reader: the Go provider's lazy reconciliation.** The status Lambdas
+are not the only code that derives run status from a container's exit code.
+`internal/provider/ecs.go::Status()` reads `task.Containers[0].ExitCode`, and
+`Finalize()` (the lazy-status path used by `horde status`/`list`/`results` when
+the Lambda is behind or failed) feeds that into `mapExitCode` to write the run's
+terminal status. With a sidecar present this has the *same* index-0 bug — a
+sidecar killed non-zero when the worker exits 0 could be reconciled as `failed`.
+So the find-by-name fix must be applied here too: a `workerContainer(containers)`
+helper finds the `horde-worker` container by name with a `containers[0]`
+fallback, mirroring the Lambdas. Covered by
+`TestECSProvider_Status_SidecarExitIgnored` (sidecar 137 at index 0, worker 0 at
+index 1 → exit 0) and `TestECSProvider_Status_NoWorkerNameFallback`.
+
 ### 3. Testing
 
 **Synth/unit (CI — `cd cdk && npm test`):**
@@ -177,29 +193,42 @@ bootstrap path if it ever gains a sidecar.
 - Event `containers: [{exitCode:0}]` (no name) → `success`. Proves legacy
   fallback.
 
-**Live e2e (developer-local, `make e2e-*`, never CI): `TestECSCDK_Sidecar`**
+**Go provider unit (`internal/provider/ecs_test.go`):**
 
-Proves it works on real Fargate before shipping:
+- `TestECSProvider_Status_SidecarExitIgnored`: task with
+  `[{name:"postgres",exit:137},{name:"horde-worker",exit:0}]` → `ExitCode == 0`.
+  Proves the reconciliation path finds the worker by name, not index.
+- `TestECSProvider_Status_NoWorkerNameFallback`: single unnamed container → that
+  container's exit. Proves the legacy fallback.
 
-- Add a Postgres sidecar to `cdk/e2e/app.ts`:
-  `worker.taskDefinition.addContainer("postgres", { image: postgres:16,
-  environment: { POSTGRES_HOST_AUTH_METHOD: "trust" }, essential: false })`.
+These deterministic unit tests are the **real proof** of the find-by-name fix,
+across all three readers (TS Lambda, Python Lambda, Go provider).
+
+**Live e2e (developer-local, `make e2e-*`, never CI): `TestECS_Sidecar`**
+
+Proves localhost reachability on real Fargate:
+
+- Add a Postgres sidecar to `cdk/e2e/app.ts` via the `sidecars` prop
+  (`postgres:16-alpine`, `POSTGRES_HOST_AUTH_METHOD: "trust"`, mem-capped,
+  essential defaults to false).
 - Add `.orc/workflows/postgres-probe.yaml` — a `type: script` phase that probes
-  `localhost:5432`. Prefer `pg_isready`/`psql` if present in the worker image;
-  otherwise a dependency-free bash `/dev/tcp/localhost/5432` TCP check. Exit 0
-  on reach, non-zero otherwise. (Implementation verifies which client exists;
-  the `/dev/tcp` fallback needs no extra tooling, so the e2e is feasible
-  regardless.)
-- `TestECSCDK_Sidecar` (in `test/integration/cdk_e2e_test.go`, gated by
-  `skipUnlessCDKE2E`) launches the probe workflow, polls DynamoDB to terminal
-  via `h.driver.StoreStatus`, and asserts `status == "success"` **and**
-  `StoreExitCode == 0`.
+  `localhost:5432` with a dependency-free bash `/dev/tcp/localhost/5432` check
+  (the worker image has no postgres client), retrying briefly. Exit 0 on reach.
+- `TestECS_Sidecar` (in `test/integration/ecs_sidecar_test.go`) runs under the
+  full `TestECS` suite with `HORDE_E2E_ECS_BACKEND=cdk`. It launches the probe
+  workflow, polls to terminal, and asserts `status == "success"` + exit 0. The
+  worker clones the canonical repo and runs the workflow from the checked-out
+  branch, so before this lands on `main` set `HORDE_E2E_SIDECAR_BRANCH=<branch>`
+  (pushed to GitHub) so the worker finds the workflow; post-merge the default
+  (main) checkout has it.
 
-This single test proves **both** properties: (a) the worker reaches the sidecar
-on `localhost`, and (b) the name-filter holds — the non-essential Postgres
-sidecar is killed (non-zero, ~137/143) when the essential worker exits 0, so if
-the Lambda read the sidecar the status would be `failed`. A green test is real
-proof.
+Scope of the e2e: it reliably proves the worker **reaches the sidecar on
+localhost** (the user-facing feature). It does **not**, on its own, prove the
+find-by-name fix — ECS does not guarantee container order, so the test cannot
+force the sidecar ahead of the worker; on a run where the worker sorts first the
+old index-0 logic would also pass. The name-filter is proven by the unit tests
+above. **Verified green on prepdesk** (run `1aawbgjq8v70` → success/0), plus the
+broader `TestECS` suite passed against the sidecar-bearing stack.
 
 ### 4. Docs & version
 
@@ -222,23 +251,28 @@ proof.
 - `cdk/src/horde-worker-props.ts` — `sidecars` prop + TSDoc
 - `cdk/src/horde-worker.ts` — `WORKER_CONTAINER_NAME` const, sidecar loop, guard,
   `sidecarContainers` field
-- `cdk/src/status-lambda/index.ts` — find-worker-by-name filter
-- `cdk/src/index.ts` — export `WORKER_CONTAINER_NAME` if needed by tests
-- `cdk/test/*.test.ts` — synth assertions
+- `cdk/src/status-lambda/index.ts` — find-worker-by-name filter (TS Lambda)
+- `cdk/src/index.ts` — export `WORKER_CONTAINER_NAME` for tests
+- `cdk/test/horde-worker-sidecars.test.ts` — synth assertions
 - `cdk/src/status-lambda/index.test.ts` — filter unit tests
 - `cdk/e2e/app.ts` — Postgres sidecar
-- `cdk/package.json` — 0.4.0
+- `cdk/package.json` + `package-lock.json` — 0.4.0
 - `cdk/README.md` — docs
 - `internal/bootstrap/templates/stack.yaml.tmpl` — Python Lambda filter (lockstep)
+- `internal/provider/ecs.go` — `workerContainer` helper; `Status()` finds the
+  worker by name (the third reader — Go lazy reconciliation)
+- `internal/provider/ecs_test.go` — `Status` sidecar + fallback unit tests
 - `internal/docs/content.go` — `topicCDK` note
 - `.orc/workflows/postgres-probe.yaml` — e2e probe workflow
-- `test/integration/cdk_e2e_test.go` — `TestECSCDK_Sidecar`
+- `test/integration/ecs_sidecar_test.go` — `TestECS_Sidecar`
 
 ## Verification
 
-- `cd cdk && npm run build && npm test` — unit + synth assertions pass.
-- `make unit-test && make vet` — Go side clean (template change compiles).
+- `cd cdk && npm run build && npm test` — unit + synth assertions pass (91).
+- `make unit-test && make vet` — Go side clean, incl. the `ecs.go` find-by-name
+  fix + its unit tests.
 - `make bootstrap-validate-test` — rendered CFN still ValidateTemplate-clean.
-- `make e2e-up && make e2e-test && make e2e-down` — live: `TestECSCDK_Sidecar`
-  green proves worker↔sidecar localhost reachability and the name-filter fix on
-  real Fargate.
+- `make e2e-up && make e2e-test && make e2e-down` — live on prepdesk:
+  `TestECS_Sidecar` green proves worker↔sidecar localhost reachability on real
+  Fargate (run `1aawbgjq8v70`). The find-by-name fix is proven by the unit tests
+  across all three readers, not the e2e (ECS container order is not forceable).

--- a/docs/superpowers/specs/2026-06-08-sidecar-containers-design.md
+++ b/docs/superpowers/specs/2026-06-08-sidecar-containers-design.md
@@ -1,0 +1,244 @@
+# Sidecar containers in the worker task definition
+
+Issue: https://github.com/jorge-barreto/horde/issues/7
+
+## Context
+
+Some projects need auxiliary containers running alongside the worker for the
+duration of a run: a Postgres/MySQL/Redis instance the test suite reaches on
+`localhost`, a headless Playwright/Selenium server, a Stripe/LocalStack mock,
+or a policy-mandated OTel sidecar. Today the `HordeWorker` CDK construct
+provisions a single-container Fargate task definition, so users bake the
+service into the worker image and start it from the entrypoint. That bloats the
+image, ties `initdb` to image-build time, and forces both processes to share one
+container's memory — prepdesk had to bump its task from 4 GB to 8 GB to fit
+embedded Postgres. A sidecar is the Fargate-native answer.
+
+Triage (issue comment) scoped v1:
+
+- **CDK-only.** A `sidecars` prop on `HordeWorkerProps`. The construct builds
+  `ContainerDefinitions` programmatically, so sidecars are just additional
+  `addContainer` calls.
+- **Docker provider parity: explicit non-goal.** No compose synthesis / docker
+  network for `--provider docker`.
+- **CFN bootstrap path: deferred.** Templating arbitrary `ContainerDefinitions`
+  YAML via Go `text/template` is the wrong tool. The Python status Lambda in the
+  template still changes (lockstep, below), but no sidecar *prop* surface is
+  added to bootstrap.
+
+### The load-bearing correctness trap
+
+Status sync keys off the **worker container's** exit, not the task's. Both
+status Lambdas (TypeScript in `cdk/src/status-lambda/index.ts`, Python in
+`internal/bootstrap/templates/stack.yaml.tmpl`) currently read
+`containers[0].exitCode` with no name filter. The ECS `Task State Change`
+event's `containers` array order is **not** documented to be stable. Once
+sidecars exist, a sidecar could land at index 0 and the Lambda would record the
+sidecar's exit code as the run status — a silent wrong-status bug. This is the
+part the triage flagged as most likely to bite.
+
+## Design
+
+### 1. The `sidecars` prop (thin wrapper over CDK's type)
+
+Add to `HordeWorkerProps` (`cdk/src/horde-worker-props.ts`):
+
+```ts
+/**
+ * Additional containers added to the worker's Fargate task definition,
+ * sharing its network namespace (reachable on localhost) and lifecycle.
+ *
+ * Each entry is passed to taskDefinition.addContainer() with two defaults
+ * applied when omitted:
+ *   - essential: false  — a crashing sidecar does not kill the run. Set
+ *     true for a dependency the worker cannot run without (e.g. a DB).
+ *   - logging          — routed to the worker's CloudWatch log group with
+ *     the sidecar's containerName as the stream prefix.
+ *
+ * memoryMiB sizes the whole task; sidecars share that ceiling unless you set
+ * a per-container memoryLimitMiB. The containerName "horde-worker" is reserved
+ * and rejected at synth time.
+ *
+ * @default — no sidecars; single-container task definition.
+ */
+readonly sidecars?: ecs.ContainerDefinitionOptions[];
+```
+
+Reuse CDK's native `ContainerDefinitionOptions` rather than a curated subset —
+callers get `healthCheck`, `dependsOn`, `portMappings`, `command`,
+`memoryLimitMiB`, `secrets` for free, and there's no parallel type to maintain.
+
+In the constructor (`cdk/src/horde-worker.ts`), **after** the worker
+`addContainer` call:
+
+```ts
+this.sidecarContainers = (props.sidecars ?? []).map((s) => {
+  if (s.containerName === WORKER_CONTAINER_NAME) {
+    throw new Error(
+      `HordeWorker: sidecar containerName "${WORKER_CONTAINER_NAME}" is ` +
+        `reserved for the worker container.`,
+    );
+  }
+  // addContainer(id, options): id is the construct id. Use the sidecar's
+  // containerName as the id when present (must be unique within the task def),
+  // else a stable index-derived id like `Sidecar${i}`.
+  return this.taskDefinition.addContainer(s.containerName ?? `Sidecar${i}`, {
+    essential: false,
+    logging: ecs.LogDriver.awsLogs({
+      logGroup: this.logGroup,
+      streamPrefix: s.containerName ?? `sidecar${i}`,
+    }),
+    ...s, // caller's explicit essential/logging override the defaults
+  });
+});
+```
+
+The merge spreads `s` last so a caller-provided `essential`/`logging` wins over
+the defaults; the snippet is illustrative of intent, not final code. Expose
+`public readonly sidecarContainers: ecs.ContainerDefinition[]`.
+
+The worker container is still added first (defensive), but correctness no longer
+depends on ordering — see §2.
+
+### 2. Centralize the worker name; find the worker by name
+
+The worker container name `"horde-worker"` is a **cross-language contract**,
+hardcoded today in:
+
+- `cdk/src/horde-worker.ts` (`containerName`)
+- `internal/provider/ecs.go:28` (`const containerName`) — used for env overrides
+  at launch and to build the CloudWatch log-stream path when reading logs
+- `internal/bootstrap/templates/stack.yaml.tmpl` (container `Name`)
+
+Within CDK, replace the literal with a single exported constant referenced by the
+worker's `containerName`, the status-Lambda filter, and the sidecar reject-guard:
+
+```ts
+export const WORKER_CONTAINER_NAME = "horde-worker";
+```
+
+Renaming the constant moves the container, the filter, and the guard together —
+no drift. **Not exposed as a prop**: the Go provider hardcodes the name for
+log-stream paths and env-override targeting and does not read it from SSM, so a
+configurable name would silently break `horde logs` and env injection for that
+deployment unless also plumbed through the SSM config blob → out of scope.
+Multiple horde stacks already coexist via `projectSlug` namespacing (separate
+clusters/SSM paths), so a configurable container name solves no real use case.
+
+Both Lambdas change exit-code extraction from "first container" to "the container
+named `horde-worker`", with a legacy fallback to `containers[0]` when no named
+container is present (preserves behavior for any single-container event lacking
+the name field):
+
+TypeScript (`cdk/src/status-lambda/index.ts`):
+
+```ts
+const containers = detail.containers ?? [];
+const worker =
+  containers.find((c) => c.name === WORKER_CONTAINER_NAME) ?? containers[0];
+const exitCode =
+  worker && typeof worker.exitCode === "number" ? worker.exitCode : null;
+```
+
+(The Lambda gets its own copy of the constant — it is bundled standalone by
+esbuild and cannot import construct code that pulls in `aws-cdk-lib`. Keep the
+two definitions adjacent / commented as paired.)
+
+Python (`internal/bootstrap/templates/stack.yaml.tmpl`), kept in lockstep:
+
+```python
+containers = detail.get("containers", [])
+worker = next((c for c in containers if c.get("name") == "horde-worker"), None)
+if worker is None and containers:
+    worker = containers[0]
+exit_code = worker.get("exitCode") if worker else None
+```
+
+This is a no-op for current single-container stacks and future-proofs the
+bootstrap path if it ever gains a sidecar.
+
+### 3. Testing
+
+**Synth/unit (CI — `cd cdk && npm test`):**
+
+- Task def with one sidecar synthesizes two `ContainerDefinitions`; worker
+  `Essential: true`, sidecar defaults `Essential: false`.
+- A sidecar with explicit `essential: true` is honored.
+- Sidecar logging defaults to the shared log group with its name as
+  `awslogs-stream-prefix`.
+- A sidecar with `containerName: "horde-worker"` throws at synth.
+- The synthesized worker container `Name` equals `WORKER_CONTAINER_NAME`
+  (documents the Go/Python lockstep dependency; a rename is caught here).
+
+**Status-Lambda unit (`cdk/src/status-lambda/index.test.ts`):**
+
+- Event `containers: [{name:"db",exitCode:1},{name:"horde-worker",exitCode:0}]`
+  → status `success`, exitCode 0. Proves name-filter beats array order.
+- Event `containers: [{exitCode:0}]` (no name) → `success`. Proves legacy
+  fallback.
+
+**Live e2e (developer-local, `make e2e-*`, never CI): `TestECSCDK_Sidecar`**
+
+Proves it works on real Fargate before shipping:
+
+- Add a Postgres sidecar to `cdk/e2e/app.ts`:
+  `worker.taskDefinition.addContainer("postgres", { image: postgres:16,
+  environment: { POSTGRES_HOST_AUTH_METHOD: "trust" }, essential: false })`.
+- Add `.orc/workflows/postgres-probe.yaml` — a `type: script` phase that probes
+  `localhost:5432`. Prefer `pg_isready`/`psql` if present in the worker image;
+  otherwise a dependency-free bash `/dev/tcp/localhost/5432` TCP check. Exit 0
+  on reach, non-zero otherwise. (Implementation verifies which client exists;
+  the `/dev/tcp` fallback needs no extra tooling, so the e2e is feasible
+  regardless.)
+- `TestECSCDK_Sidecar` (in `test/integration/cdk_e2e_test.go`, gated by
+  `skipUnlessCDKE2E`) launches the probe workflow, polls DynamoDB to terminal
+  via `h.driver.StoreStatus`, and asserts `status == "success"` **and**
+  `StoreExitCode == 0`.
+
+This single test proves **both** properties: (a) the worker reaches the sidecar
+on `localhost`, and (b) the name-filter holds — the non-essential Postgres
+sidecar is killed (non-zero, ~137/143) when the essential worker exits 0, so if
+the Lambda read the sidecar the status would be `failed`. A green test is real
+proof.
+
+### 4. Docs & version
+
+- TSDoc on the `sidecars` prop (above).
+- `cdk/README.md`: a "Sidecar containers" section with the Postgres test-DB
+  example from the issue.
+- `internal/docs/content.go` (`topicCDK`): a short sidecars note under "What it
+  Provisions".
+- Bump `cdk/package.json` `0.3.0` → `0.4.0` (backward-compatible feature).
+
+## Out of scope
+
+- Docker-provider sidecar support (compose / docker network) — explicit non-goal.
+- CFN bootstrap sidecar *prop* surface — deferred. Only the Python Lambda's
+  worker-by-name filter changes, for lockstep.
+- Making the worker container name caller-configurable.
+
+## Files touched
+
+- `cdk/src/horde-worker-props.ts` — `sidecars` prop + TSDoc
+- `cdk/src/horde-worker.ts` — `WORKER_CONTAINER_NAME` const, sidecar loop, guard,
+  `sidecarContainers` field
+- `cdk/src/status-lambda/index.ts` — find-worker-by-name filter
+- `cdk/src/index.ts` — export `WORKER_CONTAINER_NAME` if needed by tests
+- `cdk/test/*.test.ts` — synth assertions
+- `cdk/src/status-lambda/index.test.ts` — filter unit tests
+- `cdk/e2e/app.ts` — Postgres sidecar
+- `cdk/package.json` — 0.4.0
+- `cdk/README.md` — docs
+- `internal/bootstrap/templates/stack.yaml.tmpl` — Python Lambda filter (lockstep)
+- `internal/docs/content.go` — `topicCDK` note
+- `.orc/workflows/postgres-probe.yaml` — e2e probe workflow
+- `test/integration/cdk_e2e_test.go` — `TestECSCDK_Sidecar`
+
+## Verification
+
+- `cd cdk && npm run build && npm test` — unit + synth assertions pass.
+- `make unit-test && make vet` — Go side clean (template change compiles).
+- `make bootstrap-validate-test` — rendered CFN still ValidateTemplate-clean.
+- `make e2e-up && make e2e-test && make e2e-down` — live: `TestECSCDK_Sidecar`
+  green proves worker↔sidecar localhost reachability and the name-filter fix on
+  real Fargate.

--- a/internal/bootstrap/templates/stack.yaml.tmpl
+++ b/internal/bootstrap/templates/stack.yaml.tmpl
@@ -703,10 +703,17 @@ Resources:
               if not run_id:
                   return {"skipped": "task not managed by horde"}
 
+              # Status is the WORKER container's exit code, not the task's. If
+              # the task ever gains sidecars the event's `containers` order is
+              # not guaranteed, so find the worker by name; fall back to the
+              # first container for single-container events that omit the name.
               containers = detail.get("containers", [])
-              exit_code = None
-              if containers:
-                  exit_code = containers[0].get("exitCode")
+              worker = next(
+                  (c for c in containers if c.get("name") == "horde-worker"), None
+              )
+              if worker is None and containers:
+                  worker = containers[0]
+              exit_code = worker.get("exitCode") if worker else None
               # Mirrors internal/provider/docker.go::mapExitCode and the CDK
               # status lambda (cdk/src/status-lambda/index.ts): orc exit 2 ->
               # timed_out, 4 -> rate_limited, 5 -> killed (recoverable), 0 ->

--- a/internal/docs/content.go
+++ b/internal/docs/content.go
@@ -1055,6 +1055,29 @@ Same surface as 'horde bootstrap' (CloudFormation flavor):
     CliUserManagedPolicyArn — attach to the IAM principals that
     will run the CLI
 
+Sidecar containers
+------------------
+
+The 'sidecars' prop adds extra containers to the worker task definition —
+a test database, a headless browser, a mock API. They share the task's
+network namespace (reachable on localhost) and its lifecycle.
+
+    sidecars: [
+      {
+        containerName: "postgres",
+        image: ecs.ContainerImage.fromRegistry("postgres:16"),
+        environment: { POSTGRES_PASSWORD: "dev" },
+      },
+    ]
+
+Each entry is a CDK ContainerDefinitionOptions. The construct defaults
+'essential' to false (a crashing sidecar won't stop the run; set true for a
+hard dependency) and routes logging to the worker log group. Run status is
+always the worker container's exit code, never a sidecar's. 'memoryMiB' is
+the task ceiling shared across containers; set per-container 'memoryLimitMiB'
+to cap a sidecar. CDK-only — 'horde bootstrap' and '--provider docker' do
+not provision sidecars.
+
 Config defaults
 ---------------
 

--- a/internal/provider/ecs.go
+++ b/internal/provider/ecs.go
@@ -27,6 +27,23 @@ import (
 // Must match the name set by the @horde.io/cdk construct.
 const containerName = "horde-worker"
 
+// workerContainer returns the worker container from an ECS task's container
+// list, identified by name so a sidecar (#7) is never mistaken for the worker
+// when the response order varies. Falls back to the first container for legacy
+// single-container tasks whose response omits the name. Returns nil for an
+// empty list.
+func workerContainer(containers []ecstypes.Container) *ecstypes.Container {
+	for i := range containers {
+		if containers[i].Name != nil && *containers[i].Name == containerName {
+			return &containers[i]
+		}
+	}
+	if len(containers) > 0 {
+		return &containers[0]
+	}
+	return nil
+}
+
 // maxConsecutiveDescribeFailures is the number of consecutive DescribeTasks
 // errors tolerated in follow mode before stopping the log poll loop.
 const maxConsecutiveDescribeFailures = 5
@@ -307,8 +324,13 @@ func (p *ECSProvider) Status(ctx context.Context, instanceID string) (*InstanceS
 		status.FinishedAt = task.StoppedAt
 	}
 
-	if len(task.Containers) > 0 && task.Containers[0].ExitCode != nil {
-		exitCode := int(*task.Containers[0].ExitCode)
+	// Status is the WORKER container's exit code, not the task's. With sidecars
+	// in the task def the container order is not guaranteed, so find the worker
+	// by name; fall back to the first container for legacy single-container
+	// tasks whose response omits the name. Mirrors the status Lambdas
+	// (cdk/src/status-lambda/index.ts and the bootstrap template's Python port).
+	if worker := workerContainer(task.Containers); worker != nil && worker.ExitCode != nil {
+		exitCode := int(*worker.ExitCode)
 		status.ExitCode = &exitCode
 	}
 

--- a/internal/provider/ecs_test.go
+++ b/internal/provider/ecs_test.go
@@ -686,6 +686,67 @@ func TestECSProvider_Status_StoppedNonZeroExit(t *testing.T) {
 	}
 }
 
+// TestECSProvider_Status_SidecarExitIgnored guards the lazy-reconciliation
+// path against sidecar containers (#7). The ECS DescribeTasks container order
+// is not guaranteed, so Status must read the WORKER container's exit code by
+// name, not containers[0] — otherwise Finalize() would record a sidecar's
+// exit (e.g. 137 when a non-essential sidecar is killed) as the run status,
+// the same corruption the status Lambdas were fixed to avoid.
+func TestECSProvider_Status_SidecarExitIgnored(t *testing.T) {
+	t.Parallel()
+	sidecarExit := int32(137) // killed when the essential worker exited
+	workerExit := int32(0)
+	fake := &fakeECSClient{
+		describeTasksOutput: &ecs.DescribeTasksOutput{
+			Tasks: []ecstypes.Task{
+				{
+					LastStatus: aws.String("STOPPED"),
+					Containers: []ecstypes.Container{
+						{Name: aws.String("postgres"), ExitCode: &sidecarExit},
+						{Name: aws.String(containerName), ExitCode: &workerExit},
+					},
+				},
+			},
+		},
+	}
+	p := NewECSProvider(fake, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	result, err := p.Status(context.Background(), "task-arn")
+	if err != nil {
+		t.Fatalf("Status() error = %v, want nil", err)
+	}
+	if result.ExitCode == nil || *result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %v, want 0 (the worker's exit, not the sidecar's 137)", result.ExitCode)
+	}
+}
+
+// TestECSProvider_Status_NoWorkerNameFallback confirms the fallback for legacy
+// single-container tasks whose event omits the container name: read the first
+// container, preserving the pre-sidecar behavior.
+func TestECSProvider_Status_NoWorkerNameFallback(t *testing.T) {
+	t.Parallel()
+	exitCode := int32(0)
+	fake := &fakeECSClient{
+		describeTasksOutput: &ecs.DescribeTasksOutput{
+			Tasks: []ecstypes.Task{
+				{
+					LastStatus: aws.String("STOPPED"),
+					Containers: []ecstypes.Container{
+						{ExitCode: &exitCode}, // no Name
+					},
+				},
+			},
+		},
+	}
+	p := NewECSProvider(fake, &fakeCloudWatchLogsClient{}, &fakeS3Client{}, testHordeConfig())
+	result, err := p.Status(context.Background(), "task-arn")
+	if err != nil {
+		t.Fatalf("Status() error = %v, want nil", err)
+	}
+	if result.ExitCode == nil || *result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %v, want 0 (fallback to first container)", result.ExitCode)
+	}
+}
+
 func TestECSProvider_Status_Provisioning(t *testing.T) {
 	t.Parallel()
 	fake := &fakeECSClient{

--- a/test/integration/ecs_sidecar_test.go
+++ b/test/integration/ecs_sidecar_test.go
@@ -10,16 +10,20 @@ import (
 //
 // The CDK e2e stack (cdk/e2e/app.ts) adds a Postgres sidecar to the worker task
 // definition. The `postgres-probe` workflow connects to localhost:5432 from the
-// worker container and exits 0 once it reaches the sidecar. A green run proves
-// two things at once:
+// worker container and exits 0 once it reaches the sidecar.
 //
-//  1. The worker reaches the sidecar on localhost — i.e. they share the task's
-//     network namespace, the user-facing point of the feature.
-//  2. Run status reflects the WORKER's exit code, not the sidecar's. The
-//     Postgres sidecar is non-essential and is killed (non-zero, ~137/143) when
-//     the essential worker exits 0. If the status Lambda read the sidecar
-//     instead of finding the worker by name, the run would land "failed".
-//     Asserting success + exit_code 0 confirms the find-by-name fix holds.
+// What this proves: the worker REACHES the sidecar on localhost — they share the
+// task's network namespace, the user-facing point of the feature — and the run
+// completes cleanly with sidecars present.
+//
+// What it does NOT prove on its own: the find-worker-by-name fix. ECS does not
+// guarantee container order in the stop event/DescribeTasks response, so this
+// test cannot force the sidecar ahead of the worker; on a run where the worker
+// happens to sort first, even the old containers[0] logic would pass. The
+// name-filter is proven deterministically by unit tests instead:
+// cdk/src/status-lambda/index.test.ts and
+// internal/provider/ecs_test.go::TestECSProvider_Status_SidecarExitIgnored,
+// which pin a non-zero sidecar at index 0 and assert the worker's exit wins.
 //
 // The sidecar only exists on the CDK-deployed stack, so this skips unless the
 // e2e backend is cdk (HORDE_E2E_ECS_BACKEND=cdk, as set by `make e2e-test`).

--- a/test/integration/ecs_sidecar_test.go
+++ b/test/integration/ecs_sidecar_test.go
@@ -1,0 +1,55 @@
+package integration
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+// TestECS_Sidecar exercises sidecar containers (#7) end-to-end on real Fargate.
+//
+// The CDK e2e stack (cdk/e2e/app.ts) adds a Postgres sidecar to the worker task
+// definition. The `postgres-probe` workflow connects to localhost:5432 from the
+// worker container and exits 0 once it reaches the sidecar. A green run proves
+// two things at once:
+//
+//  1. The worker reaches the sidecar on localhost — i.e. they share the task's
+//     network namespace, the user-facing point of the feature.
+//  2. Run status reflects the WORKER's exit code, not the sidecar's. The
+//     Postgres sidecar is non-essential and is killed (non-zero, ~137/143) when
+//     the essential worker exits 0. If the status Lambda read the sidecar
+//     instead of finding the worker by name, the run would land "failed".
+//     Asserting success + exit_code 0 confirms the find-by-name fix holds.
+//
+// The sidecar only exists on the CDK-deployed stack, so this skips unless the
+// e2e backend is cdk (HORDE_E2E_ECS_BACKEND=cdk, as set by `make e2e-test`).
+//
+// The worker clones github.com/jorge-barreto/horde and runs the workflow from
+// the checked-out branch. Once this lands on main, the default checkout (main)
+// has postgres-probe.yaml and no branch is needed. To run the test BEFORE merge,
+// set HORDE_E2E_SIDECAR_BRANCH to the feature branch (pushed to GitHub) so the
+// worker checks it out and finds the workflow.
+func TestECS_Sidecar(t *testing.T) {
+	if os.Getenv("HORDE_E2E_ECS_BACKEND") != "cdk" {
+		t.Skip("sidecar e2e requires the CDK stack (HORDE_E2E_ECS_BACKEND=cdk)")
+	}
+	t.Parallel()
+	h := newECSHarness(t)
+
+	ticket := uniqueTicket("sidecar-postgres")
+	branch := os.Getenv("HORDE_E2E_SIDECAR_BRANCH") // empty -> worker uses default branch
+	runID := h.LaunchBranch(ticket, "postgres-probe", branch, 8*time.Minute)
+	h.TrackRunForCleanup(runID)
+
+	waitForECSTerminal(t, h, runID, 8*time.Minute)
+
+	if got := h.driver.StoreStatus(runID); got != "success" {
+		t.Fatalf("StoreStatus = %q, want %q — worker should reach the Postgres "+
+			"sidecar on localhost and exit 0 (a 'failed' here may mean the status "+
+			"Lambda read the sidecar's exit code instead of the worker's)", got, "success")
+	}
+	if ec := h.driver.StoreExitCode(runID); ec == nil || *ec != 0 {
+		t.Fatalf("StoreExitCode = %v, want 0 (the worker's exit code, not the "+
+			"non-essential sidecar's)", ec)
+	}
+}


### PR DESCRIPTION
Closes #7.

## What

Adds a `sidecars` prop to `HordeWorkerProps` so callers can run auxiliary
containers (test DBs, headless browsers, mock services) alongside the worker in
the same Fargate task. They share the task's network namespace
(localhost-reachable) and lifecycle. Scoped CDK-only per the issue triage —
docker-provider parity and the CFN bootstrap surface are out of scope.

## Design

- **`sidecars` prop** — a thin wrapper over `ecs.ContainerDefinitionOptions[]`,
  so `healthCheck`, `portMappings`, `secrets`, `command`, `dependsOn`,
  `memoryLimitMiB` are all available. The construct fills two defaults when
  omitted (caller value always wins): `essential: false` (a crashing sidecar
  doesn't fail the run) and `logging` routed to the worker log group with the
  sidecar name as stream prefix. Exposed as `worker.sidecarContainers`.

- **The load-bearing correctness fix.** Status sync keys off the *worker*
  container's exit, not the task's. Both status Lambdas read `containers[0]`
  with no name filter — and the ECS `Task State Change` event's container order
  is not guaranteed, so with sidecars present a sidecar could be read as the
  run's exit status. Both Lambdas (TS + Python bootstrap template, kept in
  lockstep) now find the worker container **by name** and fall back to
  `containers[0]` for legacy single-container events. The worker name is
  centralized as `WORKER_CONTAINER_NAME`; a sidecar that reuses it is rejected
  at synth time.

- **Bumps `@horde.io/cdk` to 0.4.0.**

## Tests

- **Unit (CI):** new `horde-worker-sidecars.test.ts` (synth assertions:
  two containers, `essential` defaults + override, shared-log-group logging,
  reserved-name guard, worker name == `WORKER_CONTAINER_NAME`). New
  status-Lambda tests: sidecar-at-index-0 → reads worker (success), and the
  legacy no-name fallback. Full CDK suite: 91 passing.
- **Go (CI):** `make vet` + `make unit-test` clean; rendered Python Lambda
  re-verified via `make bootstrap-validate-test` (ValidateTemplate).
- **Live e2e on real Fargate (prepdesk):** added a Postgres sidecar to the e2e
  CDK app and a `postgres-probe` workflow that reaches `localhost:5432`.
  `TestECS_Sidecar` deploys, launches, and asserts `success` + `exit_code 0` —
  proving (a) the worker reaches the sidecar on localhost and (b) status tracks
  the *worker's* exit, not the non-essential sidecar's (which is killed non-zero
  when the worker exits). **Verified green**, plus the broader `TestECS` suite
  passed against the sidecar-bearing stack with no regression. Stack torn down.

  Note: the worker clones the canonical repo and runs the workflow from the
  checked-out branch, so before this lands on `main` the e2e needs
  `HORDE_E2E_SIDECAR_BRANCH=<branch>` to point the worker at a branch with the
  workflow. After merge the default (main) checkout has it and no override is
  needed.

## Spec

Design doc: `docs/superpowers/specs/2026-06-08-sidecar-containers-design.md`.