### PR TITLE
docs: fix install env-var example (vars must go on the sh side of the pipe)

### DIFF
--- a/internal/docs/content.go
+++ b/internal/docs/content.go
@@ -820,10 +820,12 @@ Download the latest release binary:
 
     curl -fsSL https://raw.githubusercontent.com/jorge-barreto/horde/main/scripts/install.sh | sh
 
-Pin a version or change the install directory:
+Pin a version or change the install directory. Note the env vars go on the
+'sh' side of the pipe, not before 'curl' — 'VAR=x curl ... | sh' would set the
+var for curl, not the script:
 
-    HORDE_VERSION=v0.1.0 HORDE_BINDIR="$HOME/.local/bin" \
-      curl -fsSL https://raw.githubusercontent.com/jorge-barreto/horde/main/scripts/install.sh | sh
+    curl -fsSL https://raw.githubusercontent.com/jorge-barreto/horde/main/scripts/install.sh \
+      | HORDE_VERSION=v0.4.0 HORDE_BINDIR="$HOME/.local/bin" sh
 
 The script detects your OS/arch, downloads the matching release archive,
 verifies its SHA-256 checksum, and installs the binary.


### PR DESCRIPTION
## Summary

The `horde docs install` example for pinning a version / install dir put the env vars **before `curl`**:

```
HORDE_VERSION=... HORDE_BINDIR=... curl ... | sh   # ❌ vars set on curl, not the piped script
```

In `VAR=x curl ... | sh`, the var is set for the `curl` process only — the `sh` that executes the downloaded script never sees it, so `HORDE_VERSION`/`HORDE_BINDIR` were silently ignored. Fixed to put them on the `sh` side:

```
curl ... | HORDE_VERSION=v0.4.0 HORDE_BINDIR="$HOME/.local/bin" sh   # ✅
```

Also bumped the example version to `v0.4.0` (the actual first CLI release) and added a one-line note explaining the pipe-side gotcha.

## Verification

Reproduced live against the `v0.4.0` release: the old form ignored `HORDE_BINDIR` (binary landed in the default `~/.local/bin`); the corrected form installed to the requested dir. Docs render correctly; `go test ./internal/docs/` passes.

Docs-only change to one `internal/docs/content.go` string constant — no code paths affected.