### PR TITLE
Release 0.5.0

### DIFF
--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@horde.io/cdk",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@horde.io/cdk",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "devDependencies": {
         "@aws-sdk/client-dynamodb": "^3.600.0",

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@horde.io/cdk",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "AWS CDK construct that provisions the infrastructure required by horde (https://github.com/jorge-barreto/horde): ECS Fargate cluster, DynamoDB runs table, S3 artifacts bucket, SSM config parameter, EventBridge status sync, and scoped IAM.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Cuts the **0.5.0** release for both artifacts.

## What's in 0.5.0 (since v0.4.0)

- **Run-lifecycle event backbone → queue + spend-rate cap** (#55): custom EventBridge bus carrying `run.started`/`run.terminal`/`run.cost-threshold-exceeded`; `horde launch --enqueue` + `horde queue list|prioritize|cancel`; realized-spend rate cap on the drain. (aws-ecs / CDK-only)
- **Token-level telemetry on runs** (#49): per-run input/output/cache token totals, surfaced under `--json` and summed into the list summary.
- **Canonical bucket key + overrideable launch identity** (#47): repo URL normalized to one history bucket regardless of clone form; every discovery step overrideable for programmatic callers.

All changes are backward-compatible additions → minor bump.

## Release mechanics

This PR only bumps `cdk/package.json` (+lockfile) to `0.5.0`. On merge to `main`:

- `tag-on-bump.yml` auto-pushes `cdk-v0.5.0` → `publish.yml` publishes `@horde.io/cdk@0.5.0` to npm.
- The CLI `v0.5.0` tag is pushed separately (post-merge) to fire `release-cli.yml` (GoReleaser).