### PR TITLE
ci: bump actions to Node 24 majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache: true
 
       - run: make vet
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache: true
 
       # ubuntu-latest ships Docker pre-installed; preflight so we fail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
     name: unit-test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.24"
           cache: true
@@ -32,9 +32,9 @@ jobs:
     name: integration-test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.24"
           cache: true
@@ -52,9 +52,9 @@ jobs:
       run:
         working-directory: cdk
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: npm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
       run:
         working-directory: cdk
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Node 24: ships npm >= 11.5.1, which is required for trusted-publisher
       # OIDC publish. Node 22 LTS still bundles npm 10.x; with npm 10 the
@@ -32,7 +32,7 @@ jobs:
       # actions/runner-images#13883 (promise-retry MODULE_NOT_FOUND mid-install).
       # Bumping node-version is the canonical fix per npm's trusted-publishers
       # docs example.
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -16,16 +16,16 @@ jobs:
     name: release-cli
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # GoReleaser needs full history for the changelog
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.24"
           cache: true
 
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@v7
         with:
           # pinned (not floating ~> v2) so a future v2 that removes brews: can't break releases silently
           version: "2.12.7"

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache: true
 
       - uses: goreleaser/goreleaser-action@v7

--- a/.github/workflows/tag-on-bump.yml
+++ b/.github/workflows/tag-on-bump.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       # fetch-depth 2 so HEAD~1 (the pre-merge parent) is available for the
       # version diff. Squash-merge to main means HEAD~1 is the correct "before".
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 2
           token: ${{ secrets.RELEASE_TAG_PAT }}


### PR DESCRIPTION
## Why

The `release-cli` and `publish-cdk` runs for v0.5.0 logged the Node 20 deprecation warning:

> Node.js 20 actions are deprecated. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

This bumps every JavaScript action to the latest major whose runtime is `node24`, ahead of those dates.

## Changes

### Action major bumps (all four workflows)

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/setup-go` | v5 | v6 |
| `actions/setup-node` | v4 | v6 |
| `goreleaser/goreleaser-action` | v6 | v7 |

I confirmed each target major declares `runs.using: node24` in its `action.yml`.

### setup-go pin 1.24 to 1.25 (latent bug surfaced by the bump)

`go.mod` requires `go 1.25.0`, but the `setup-go` pin was still `1.24`. Under `setup-go@v5` this was masked: `GOTOOLCHAIN` was unset, so Go auto-downloaded 1.25 to satisfy the module. `setup-go@v6` defaults `GOTOOLCHAIN=local`, which forbids that download, so `go vet` failed immediately with `go.mod requires go >= 1.25.0 (running go 1.24)`.

The Dockerfiles already build on `golang:1.25`, so 1.25 is the real toolchain everywhere except this stale CI pin. Aligned the three `setup-go` pins (ci unit-test, ci integration-test, release-cli) with `go.mod`. Verified locally by reproducing CI conditions (`GOTOOLCHAIN=local` + a real Go 1.25.0 toolchain): `go vet` and the full unit suite pass.

## What deliberately did NOT change

- GoReleaser binary pin (`version: "2.12.7"` in `release-cli.yml`): that pin holds the GoReleaser CLI major (guards against a v2 dropping `brews:`); bumping the action wrapper to v7 leaves it untouched, so the Homebrew formula push is unaffected.
- `node-version` toolchain values (`"22"` in ci, `"24"` in publish): these set the Node the job uses (npm 11 / OIDC in publish), distinct from the action runtime. Unchanged.

## Breaking-change review

- checkout v4 to v6: Node 24 runtime + internal credential-storage change; requires runner >= v2.327.1 (hosted runners are past that). Our `token:`-based PAT usage in `tag-on-bump` still works.
- setup-go v5 to v6: defaults `GOTOOLCHAIN=local` (the trigger above) + Node 24; addressed by the 1.25 pin.
- setup-node v4 to v6 / goreleaser-action v6 to v7: runtime + internal dep bumps only; our inputs are stable across the majors.
