### PR TITLE
Pin orc to v0.1.1 in the worker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,9 @@
 FROM golang:1.25-bookworm AS builder
 ENV GOBIN=/out
+# Pinned for reproducible builds. Bump with intent (mirrors CLAUDE_VERSION below).
+ARG ORC_VERSION=v0.1.1
 RUN mkdir -p /out \
-    && go install github.com/jorge-barreto/orc/cmd/orc@latest \
+    && go install github.com/jorge-barreto/orc/cmd/orc@${ORC_VERSION} \
     && go install github.com/jorge-barreto/bd/cmd/bd@latest
 
 FROM debian:bookworm-slim


### PR DESCRIPTION
Stops the worker image from silently tracking orc HEAD. Mirrors the existing `CLAUDE_VERSION` pin pattern with an `ORC_VERSION` build arg.

## What

`docker/Dockerfile` builder stage:
- `go install …/orc/cmd/orc@latest` → `@${ORC_VERSION}`, `ARG ORC_VERSION=v0.1.1`, with a "bump with intent" comment matching `CLAUDE_VERSION`.
- `bd` stays `@latest` (separate, out of scope).

## Why v0.1.1 (not v0.1.0)

The first orc release (v0.1.0) had a version-reporting gap: `go install @vX` does a plain compile (no ldflags), so `orc --version` reported `dev`. orc v0.1.1 adds a `runtime/debug.BuildInfo` fallback (orc PR #6), so a pinned install now self-reports its version. Pinning v0.1.1 gets both the version pin AND correct `--version` reporting.

## Verification

Built the worker builder stage with this pin and ran the binary:

```
$ docker build -f docker/Dockerfile --target builder -t t docker/
$ docker run --rm t /out/orc --version
orc version v0.1.1 (none, built unknown)
```

Confirms the pin resolves to the released tag (not HEAD) and orc self-reports `v0.1.1`. orc HEAD changes no longer reach horde without a deliberate `ORC_VERSION` bump.