### PR TITLE
cdk: networkMode public-subnet default, drop the NAT

### DIFF
--- a/cdk/src/horde-worker-props.ts
+++ b/cdk/src/horde-worker-props.ts
@@ -5,6 +5,9 @@ import type { IRepository } from "aws-cdk-lib/aws-ecr";
 import type { IBucket } from "aws-cdk-lib/aws-s3";
 import type { ISecret } from "aws-cdk-lib/aws-secretsmanager";
 
+/** Network posture for worker tasks. See `HordeWorkerProps.networkMode`. */
+export type HordeNetworkMode = "public" | "private";
+
 /**
  * Secrets injected into the worker container at runtime via ECS Secrets
  * Manager `valueFrom` (resolved by the task execution role at container start
@@ -70,9 +73,33 @@ export interface HordeWorkerProps {
 
   /**
    * VPC the Fargate tasks run in.
-   * @default — a new VPC with 2 private + 2 public subnets is created.
+   * @default — a new VPC. In `networkMode: 'public'` (the default) it has only
+   *   public subnets and no NAT Gateway; in `'private'` it adds
+   *   PRIVATE_WITH_EGRESS subnets and one NAT Gateway.
    */
   readonly vpc?: IVpc;
+
+  /**
+   * Network posture for the worker tasks.
+   *
+   * - `'public'` (default): tasks run in PUBLIC subnets with a public IPv4
+   *   address and reach the internet directly via the Internet Gateway — no
+   *   NAT Gateway is created (~$32/mo saved). The worker security group has no
+   *   ingress rules, so the public IP enables egress only; nothing on the
+   *   internet can open a connection to the task.
+   * - `'private'`: tasks run in PRIVATE_WITH_EGRESS subnets with no public IP,
+   *   reaching the internet through a NAT Gateway the construct creates. Choose
+   *   this to limit the blast radius of a future ingress rule, or when workers
+   *   must reach private VPC resources without an internet path.
+   *
+   * With a bring-your-own `vpc`, this selects which of that VPC's subnets to
+   * use; a synth-time error is raised if the VPC has no subnets of the chosen
+   * type. The default is `'public'` in all cases — supplying a VPC does not
+   * change it.
+   *
+   * @default 'public'
+   */
+  readonly networkMode?: HordeNetworkMode;
 
   /**
    * S3 bucket used to store run artifacts under `horde-runs/<runId>/`.

--- a/cdk/src/horde-worker.ts
+++ b/cdk/src/horde-worker.ts
@@ -391,11 +391,15 @@ export class HordeWorker extends Construct {
         : ec2.SubnetType.PRIVATE_WITH_EGRESS;
     const subnetTypeName =
       networkMode === "public" ? "PUBLIC" : "PRIVATE_WITH_EGRESS";
-    const selectedSubnetIds = this.vpc.selectSubnets({ subnetType }).subnetIds;
-    if (selectedSubnetIds.length === 0) {
+    let selectedSubnetIds: string[];
+    try {
+      selectedSubnetIds = this.vpc.selectSubnets({ subnetType }).subnetIds;
+    } catch (cause) {
       throw new Error(
-        `HordeWorker networkMode '${networkMode}' requires ` +
-          `ec2.SubnetType.${subnetTypeName} subnets in the VPC, but none were found.`,
+        `HordeWorker networkMode '${networkMode}' requires ec2.SubnetType.` +
+          `${subnetTypeName} subnets in the VPC, but none were found. ` +
+          `Provide a VPC with ${subnetTypeName} subnets or change networkMode. ` +
+          `(${(cause as Error).message})`,
       );
     }
     const assignPublicIp = networkMode === "public" ? "ENABLED" : "DISABLED";

--- a/cdk/src/horde-worker.ts
+++ b/cdk/src/horde-worker.ts
@@ -176,6 +176,7 @@ export class HordeWorker extends Construct {
     const cpu = props.cpu ?? 1024;
     const memoryLimitMiB = props.memoryMiB ?? 4096;
     const retention = toRetention(props.logRetentionDays ?? 30);
+    const networkMode = props.networkMode ?? "public";
 
     cdk.Tags.of(this).add("Name", `horde-${slug}`);
 
@@ -184,16 +185,21 @@ export class HordeWorker extends Construct {
     } else {
       const vpc = new ec2.Vpc(this, "Vpc", {
         maxAzs: 2,
-        natGateways: 1,
+        // 'public': no NAT, tasks egress directly via the IGW. 'private': one
+        // NAT Gateway fronting PRIVATE_WITH_EGRESS subnets.
+        natGateways: networkMode === "public" ? 0 : 1,
         vpcName: `horde-${slug}-vpc`,
-        subnetConfiguration: [
-          { name: "public", subnetType: ec2.SubnetType.PUBLIC, cidrMask: 24 },
-          {
-            name: "private",
-            subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
-            cidrMask: 24,
-          },
-        ],
+        subnetConfiguration:
+          networkMode === "public"
+            ? [{ name: "public", subnetType: ec2.SubnetType.PUBLIC, cidrMask: 24 }]
+            : [
+                { name: "public", subnetType: ec2.SubnetType.PUBLIC, cidrMask: 24 },
+                {
+                  name: "private",
+                  subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
+                  cidrMask: 24,
+                },
+              ],
       });
       cdk.Tags.of(vpc).add("Name", `horde-${slug}-vpc`);
       this.vpc = vpc;
@@ -379,9 +385,18 @@ export class HordeWorker extends Construct {
     // SSM config parameter consumed by the horde CLI. JSON keys must match
     // `internal/config/ssm.go::HordeConfig` exactly.
     const ssmPath = props.ssmParameterPath ?? `/horde/${slug}/config`;
-    const privateSubnetIds = this.vpc.selectSubnets({
-      subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
-    }).subnetIds;
+    const subnetType =
+      networkMode === "public"
+        ? ec2.SubnetType.PUBLIC
+        : ec2.SubnetType.PRIVATE_WITH_EGRESS;
+    const selectedSubnetIds = this.vpc.selectSubnets({ subnetType }).subnetIds;
+    if (selectedSubnetIds.length === 0) {
+      throw new Error(
+        `HordeWorker networkMode '${networkMode}' requires ${subnetType} subnets ` +
+          `in the VPC, but none were found.`,
+      );
+    }
+    const assignPublicIp = networkMode === "public" ? "ENABLED" : "DISABLED";
     const maxConcurrent = props.maxConcurrent ?? 5;
     const defaultTimeoutMinutes = props.defaultTimeoutMinutes ?? 1440;
 
@@ -407,7 +422,7 @@ export class HordeWorker extends Construct {
 
     const subnetsJson = cdk.Fn.join("", [
       "[",
-      cdk.Fn.join(",", privateSubnetIds.map((id) => cdk.Fn.join("", ['"', id, '"']))),
+      cdk.Fn.join(",", selectedSubnetIds.map((id) => cdk.Fn.join("", ['"', id, '"']))),
       "]",
     ]);
     const configJson = cdk.Fn.join("", [
@@ -419,7 +434,9 @@ export class HordeWorker extends Construct {
       subnetsJson,
       ',"security_group":"',
       this.workerSecurityGroup.securityGroupId,
-      '","assign_public_ip":"DISABLED","log_group":"',
+      '","assign_public_ip":"',
+      assignPublicIp,
+      '","log_group":"',
       this.logGroup.logGroupName,
       '","log_stream_prefix":"ecs","artifacts_bucket":"',
       this.artifactsBucket.bucketName,
@@ -567,9 +584,9 @@ export class HordeWorker extends Construct {
       MAX_CONCURRENT: String(maxConcurrent),
       CLUSTER_ARN: this.cluster.clusterArn,
       TASK_DEF_ARN: this.taskDefinition.taskDefinitionArn,
-      SUBNETS: cdk.Fn.join(",", privateSubnetIds),
+      SUBNETS: cdk.Fn.join(",", selectedSubnetIds),
       SECURITY_GROUP: this.workerSecurityGroup.securityGroupId,
-      ASSIGN_PUBLIC_IP: "DISABLED", // matches the SSM config above
+      ASSIGN_PUBLIC_IP: assignPublicIp, // matches the SSM config above
       ARTIFACTS_BUCKET: this.artifactsBucket.bucketName,
     };
     if (props.maxSpendPerWindow !== undefined) {

--- a/cdk/src/horde-worker.ts
+++ b/cdk/src/horde-worker.ts
@@ -389,11 +389,13 @@ export class HordeWorker extends Construct {
       networkMode === "public"
         ? ec2.SubnetType.PUBLIC
         : ec2.SubnetType.PRIVATE_WITH_EGRESS;
+    const subnetTypeName =
+      networkMode === "public" ? "PUBLIC" : "PRIVATE_WITH_EGRESS";
     const selectedSubnetIds = this.vpc.selectSubnets({ subnetType }).subnetIds;
     if (selectedSubnetIds.length === 0) {
       throw new Error(
-        `HordeWorker networkMode '${networkMode}' requires ${subnetType} subnets ` +
-          `in the VPC, but none were found.`,
+        `HordeWorker networkMode '${networkMode}' requires ` +
+          `ec2.SubnetType.${subnetTypeName} subnets in the VPC, but none were found.`,
       );
     }
     const assignPublicIp = networkMode === "public" ? "ENABLED" : "DISABLED";

--- a/cdk/src/index.ts
+++ b/cdk/src/index.ts
@@ -1,2 +1,2 @@
 export { HordeWorker, WORKER_CONTAINER_NAME } from "./horde-worker";
-export type { HordeWorkerProps, HordeWorkerSecrets } from "./horde-worker-props";
+export type { HordeNetworkMode, HordeWorkerProps, HordeWorkerSecrets } from "./horde-worker-props";

--- a/cdk/test/__snapshots__/horde-worker-matrix.test.ts.snap
+++ b/cdk/test/__snapshots__/horde-worker-matrix.test.ts.snap
@@ -451,7 +451,7 @@ exports[`HordeWorker matrix — default (no vpc, no bucket) matches the saved sn
                         [
                           """,
                           {
-                            "Ref": "HordeVpcprivateSubnet1Subnet50085241",
+                            "Ref": "HordeVpcpublicSubnet1Subnet246CEB9F",
                           },
                           """,
                         ],
@@ -463,7 +463,7 @@ exports[`HordeWorker matrix — default (no vpc, no bucket) matches the saved sn
                         [
                           """,
                           {
-                            "Ref": "HordeVpcprivateSubnet2Subnet9297B1D5",
+                            "Ref": "HordeVpcpublicSubnet2Subnet6A9C5AB6",
                           },
                           """,
                         ],
@@ -479,7 +479,7 @@ exports[`HordeWorker matrix — default (no vpc, no bucket) matches the saved sn
                   "GroupId",
                 ],
               },
-              "","assign_public_ip":"DISABLED","log_group":"",
+              "","assign_public_ip":"ENABLED","log_group":"",
               {
                 "Ref": "HordeLogGroup1EE05984",
               },
@@ -576,7 +576,7 @@ exports[`HordeWorker matrix — default (no vpc, no bucket) matches the saved sn
             "ARTIFACTS_BUCKET": {
               "Ref": "HordeArtifactsBucket1A7FD4A4",
             },
-            "ASSIGN_PUBLIC_IP": "DISABLED",
+            "ASSIGN_PUBLIC_IP": "ENABLED",
             "CLUSTER_ARN": {
               "Fn::GetAtt": [
                 "HordeClusterA7629518",
@@ -601,10 +601,10 @@ exports[`HordeWorker matrix — default (no vpc, no bucket) matches the saved sn
                 ",",
                 [
                   {
-                    "Ref": "HordeVpcprivateSubnet1Subnet50085241",
+                    "Ref": "HordeVpcpublicSubnet1Subnet246CEB9F",
                   },
                   {
-                    "Ref": "HordeVpcprivateSubnet2Subnet9297B1D5",
+                    "Ref": "HordeVpcpublicSubnet2Subnet6A9C5AB6",
                   },
                 ],
               ],
@@ -1494,130 +1494,6 @@ exports[`HordeWorker matrix — default (no vpc, no bucket) matches the saved sn
       },
       "Type": "AWS::EC2::VPCGatewayAttachment",
     },
-    "HordeVpcprivateSubnet1DefaultRoute184FFD8B": {
-      "Properties": {
-        "DestinationCidrBlock": "0.0.0.0/0",
-        "NatGatewayId": {
-          "Ref": "HordeVpcpublicSubnet1NATGateway73FD7C1D",
-        },
-        "RouteTableId": {
-          "Ref": "HordeVpcprivateSubnet1RouteTableE564B7A0",
-        },
-      },
-      "Type": "AWS::EC2::Route",
-    },
-    "HordeVpcprivateSubnet1RouteTableAssociationE29E1B5E": {
-      "Properties": {
-        "RouteTableId": {
-          "Ref": "HordeVpcprivateSubnet1RouteTableE564B7A0",
-        },
-        "SubnetId": {
-          "Ref": "HordeVpcprivateSubnet1Subnet50085241",
-        },
-      },
-      "Type": "AWS::EC2::SubnetRouteTableAssociation",
-    },
-    "HordeVpcprivateSubnet1RouteTableE564B7A0": {
-      "Properties": {
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "TestStack/Horde/Vpc/privateSubnet1",
-          },
-        ],
-        "VpcId": {
-          "Ref": "HordeVpcB5939D5D",
-        },
-      },
-      "Type": "AWS::EC2::RouteTable",
-    },
-    "HordeVpcprivateSubnet1Subnet50085241": {
-      "Properties": {
-        "AvailabilityZone": "dummy1a",
-        "CidrBlock": "10.0.2.0/24",
-        "MapPublicIpOnLaunch": false,
-        "Tags": [
-          {
-            "Key": "aws-cdk:subnet-name",
-            "Value": "private",
-          },
-          {
-            "Key": "aws-cdk:subnet-type",
-            "Value": "Private",
-          },
-          {
-            "Key": "Name",
-            "Value": "TestStack/Horde/Vpc/privateSubnet1",
-          },
-        ],
-        "VpcId": {
-          "Ref": "HordeVpcB5939D5D",
-        },
-      },
-      "Type": "AWS::EC2::Subnet",
-    },
-    "HordeVpcprivateSubnet2DefaultRoute791A061F": {
-      "Properties": {
-        "DestinationCidrBlock": "0.0.0.0/0",
-        "NatGatewayId": {
-          "Ref": "HordeVpcpublicSubnet1NATGateway73FD7C1D",
-        },
-        "RouteTableId": {
-          "Ref": "HordeVpcprivateSubnet2RouteTableB22C6503",
-        },
-      },
-      "Type": "AWS::EC2::Route",
-    },
-    "HordeVpcprivateSubnet2RouteTableAssociationAAC23162": {
-      "Properties": {
-        "RouteTableId": {
-          "Ref": "HordeVpcprivateSubnet2RouteTableB22C6503",
-        },
-        "SubnetId": {
-          "Ref": "HordeVpcprivateSubnet2Subnet9297B1D5",
-        },
-      },
-      "Type": "AWS::EC2::SubnetRouteTableAssociation",
-    },
-    "HordeVpcprivateSubnet2RouteTableB22C6503": {
-      "Properties": {
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "TestStack/Horde/Vpc/privateSubnet2",
-          },
-        ],
-        "VpcId": {
-          "Ref": "HordeVpcB5939D5D",
-        },
-      },
-      "Type": "AWS::EC2::RouteTable",
-    },
-    "HordeVpcprivateSubnet2Subnet9297B1D5": {
-      "Properties": {
-        "AvailabilityZone": "dummy1b",
-        "CidrBlock": "10.0.3.0/24",
-        "MapPublicIpOnLaunch": false,
-        "Tags": [
-          {
-            "Key": "aws-cdk:subnet-name",
-            "Value": "private",
-          },
-          {
-            "Key": "aws-cdk:subnet-type",
-            "Value": "Private",
-          },
-          {
-            "Key": "Name",
-            "Value": "TestStack/Horde/Vpc/privateSubnet2",
-          },
-        ],
-        "VpcId": {
-          "Ref": "HordeVpcB5939D5D",
-        },
-      },
-      "Type": "AWS::EC2::Subnet",
-    },
     "HordeVpcpublicSubnet1DefaultRoute071AE970": {
       "DependsOn": [
         "HordeVpcVPCGWAEEB195C",
@@ -1632,42 +1508,6 @@ exports[`HordeWorker matrix — default (no vpc, no bucket) matches the saved sn
         },
       },
       "Type": "AWS::EC2::Route",
-    },
-    "HordeVpcpublicSubnet1EIP9B0718C2": {
-      "Properties": {
-        "Domain": "vpc",
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "TestStack/Horde/Vpc/publicSubnet1",
-          },
-        ],
-      },
-      "Type": "AWS::EC2::EIP",
-    },
-    "HordeVpcpublicSubnet1NATGateway73FD7C1D": {
-      "DependsOn": [
-        "HordeVpcpublicSubnet1DefaultRoute071AE970",
-        "HordeVpcpublicSubnet1RouteTableAssociation962A9F88",
-      ],
-      "Properties": {
-        "AllocationId": {
-          "Fn::GetAtt": [
-            "HordeVpcpublicSubnet1EIP9B0718C2",
-            "AllocationId",
-          ],
-        },
-        "SubnetId": {
-          "Ref": "HordeVpcpublicSubnet1Subnet246CEB9F",
-        },
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "TestStack/Horde/Vpc/publicSubnet1",
-          },
-        ],
-      },
-      "Type": "AWS::EC2::NatGateway",
     },
     "HordeVpcpublicSubnet1RouteTableAssociation962A9F88": {
       "Properties": {
@@ -2086,7 +1926,7 @@ exports[`HordeWorker matrix — provided bucket matches the saved snapshot 1`] =
                         [
                           """,
                           {
-                            "Ref": "HordeVpcprivateSubnet1Subnet50085241",
+                            "Ref": "HordeVpcpublicSubnet1Subnet246CEB9F",
                           },
                           """,
                         ],
@@ -2098,7 +1938,7 @@ exports[`HordeWorker matrix — provided bucket matches the saved snapshot 1`] =
                         [
                           """,
                           {
-                            "Ref": "HordeVpcprivateSubnet2Subnet9297B1D5",
+                            "Ref": "HordeVpcpublicSubnet2Subnet6A9C5AB6",
                           },
                           """,
                         ],
@@ -2114,7 +1954,7 @@ exports[`HordeWorker matrix — provided bucket matches the saved snapshot 1`] =
                   "GroupId",
                 ],
               },
-              "","assign_public_ip":"DISABLED","log_group":"",
+              "","assign_public_ip":"ENABLED","log_group":"",
               {
                 "Ref": "HordeLogGroup1EE05984",
               },
@@ -2211,7 +2051,7 @@ exports[`HordeWorker matrix — provided bucket matches the saved snapshot 1`] =
             "ARTIFACTS_BUCKET": {
               "Ref": "ProvidedBucket8A3897F1",
             },
-            "ASSIGN_PUBLIC_IP": "DISABLED",
+            "ASSIGN_PUBLIC_IP": "ENABLED",
             "CLUSTER_ARN": {
               "Fn::GetAtt": [
                 "HordeClusterA7629518",
@@ -2236,10 +2076,10 @@ exports[`HordeWorker matrix — provided bucket matches the saved snapshot 1`] =
                 ",",
                 [
                   {
-                    "Ref": "HordeVpcprivateSubnet1Subnet50085241",
+                    "Ref": "HordeVpcpublicSubnet1Subnet246CEB9F",
                   },
                   {
-                    "Ref": "HordeVpcprivateSubnet2Subnet9297B1D5",
+                    "Ref": "HordeVpcpublicSubnet2Subnet6A9C5AB6",
                   },
                 ],
               ],
@@ -3129,130 +2969,6 @@ exports[`HordeWorker matrix — provided bucket matches the saved snapshot 1`] =
       },
       "Type": "AWS::EC2::VPCGatewayAttachment",
     },
-    "HordeVpcprivateSubnet1DefaultRoute184FFD8B": {
-      "Properties": {
-        "DestinationCidrBlock": "0.0.0.0/0",
-        "NatGatewayId": {
-          "Ref": "HordeVpcpublicSubnet1NATGateway73FD7C1D",
-        },
-        "RouteTableId": {
-          "Ref": "HordeVpcprivateSubnet1RouteTableE564B7A0",
-        },
-      },
-      "Type": "AWS::EC2::Route",
-    },
-    "HordeVpcprivateSubnet1RouteTableAssociationE29E1B5E": {
-      "Properties": {
-        "RouteTableId": {
-          "Ref": "HordeVpcprivateSubnet1RouteTableE564B7A0",
-        },
-        "SubnetId": {
-          "Ref": "HordeVpcprivateSubnet1Subnet50085241",
-        },
-      },
-      "Type": "AWS::EC2::SubnetRouteTableAssociation",
-    },
-    "HordeVpcprivateSubnet1RouteTableE564B7A0": {
-      "Properties": {
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "TestStack/Horde/Vpc/privateSubnet1",
-          },
-        ],
-        "VpcId": {
-          "Ref": "HordeVpcB5939D5D",
-        },
-      },
-      "Type": "AWS::EC2::RouteTable",
-    },
-    "HordeVpcprivateSubnet1Subnet50085241": {
-      "Properties": {
-        "AvailabilityZone": "dummy1a",
-        "CidrBlock": "10.0.2.0/24",
-        "MapPublicIpOnLaunch": false,
-        "Tags": [
-          {
-            "Key": "aws-cdk:subnet-name",
-            "Value": "private",
-          },
-          {
-            "Key": "aws-cdk:subnet-type",
-            "Value": "Private",
-          },
-          {
-            "Key": "Name",
-            "Value": "TestStack/Horde/Vpc/privateSubnet1",
-          },
-        ],
-        "VpcId": {
-          "Ref": "HordeVpcB5939D5D",
-        },
-      },
-      "Type": "AWS::EC2::Subnet",
-    },
-    "HordeVpcprivateSubnet2DefaultRoute791A061F": {
-      "Properties": {
-        "DestinationCidrBlock": "0.0.0.0/0",
-        "NatGatewayId": {
-          "Ref": "HordeVpcpublicSubnet1NATGateway73FD7C1D",
-        },
-        "RouteTableId": {
-          "Ref": "HordeVpcprivateSubnet2RouteTableB22C6503",
-        },
-      },
-      "Type": "AWS::EC2::Route",
-    },
-    "HordeVpcprivateSubnet2RouteTableAssociationAAC23162": {
-      "Properties": {
-        "RouteTableId": {
-          "Ref": "HordeVpcprivateSubnet2RouteTableB22C6503",
-        },
-        "SubnetId": {
-          "Ref": "HordeVpcprivateSubnet2Subnet9297B1D5",
-        },
-      },
-      "Type": "AWS::EC2::SubnetRouteTableAssociation",
-    },
-    "HordeVpcprivateSubnet2RouteTableB22C6503": {
-      "Properties": {
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "TestStack/Horde/Vpc/privateSubnet2",
-          },
-        ],
-        "VpcId": {
-          "Ref": "HordeVpcB5939D5D",
-        },
-      },
-      "Type": "AWS::EC2::RouteTable",
-    },
-    "HordeVpcprivateSubnet2Subnet9297B1D5": {
-      "Properties": {
-        "AvailabilityZone": "dummy1b",
-        "CidrBlock": "10.0.3.0/24",
-        "MapPublicIpOnLaunch": false,
-        "Tags": [
-          {
-            "Key": "aws-cdk:subnet-name",
-            "Value": "private",
-          },
-          {
-            "Key": "aws-cdk:subnet-type",
-            "Value": "Private",
-          },
-          {
-            "Key": "Name",
-            "Value": "TestStack/Horde/Vpc/privateSubnet2",
-          },
-        ],
-        "VpcId": {
-          "Ref": "HordeVpcB5939D5D",
-        },
-      },
-      "Type": "AWS::EC2::Subnet",
-    },
     "HordeVpcpublicSubnet1DefaultRoute071AE970": {
       "DependsOn": [
         "HordeVpcVPCGWAEEB195C",
@@ -3267,42 +2983,6 @@ exports[`HordeWorker matrix — provided bucket matches the saved snapshot 1`] =
         },
       },
       "Type": "AWS::EC2::Route",
-    },
-    "HordeVpcpublicSubnet1EIP9B0718C2": {
-      "Properties": {
-        "Domain": "vpc",
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "TestStack/Horde/Vpc/publicSubnet1",
-          },
-        ],
-      },
-      "Type": "AWS::EC2::EIP",
-    },
-    "HordeVpcpublicSubnet1NATGateway73FD7C1D": {
-      "DependsOn": [
-        "HordeVpcpublicSubnet1DefaultRoute071AE970",
-        "HordeVpcpublicSubnet1RouteTableAssociation962A9F88",
-      ],
-      "Properties": {
-        "AllocationId": {
-          "Fn::GetAtt": [
-            "HordeVpcpublicSubnet1EIP9B0718C2",
-            "AllocationId",
-          ],
-        },
-        "SubnetId": {
-          "Ref": "HordeVpcpublicSubnet1Subnet246CEB9F",
-        },
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "TestStack/Horde/Vpc/publicSubnet1",
-          },
-        ],
-      },
-      "Type": "AWS::EC2::NatGateway",
     },
     "HordeVpcpublicSubnet1RouteTableAssociation962A9F88": {
       "Properties": {
@@ -3729,7 +3409,7 @@ exports[`HordeWorker matrix — provided vpc and bucket matches the saved snapsh
                         [
                           """,
                           {
-                            "Ref": "ProvidedVpcPrivateSubnet1Subnet6AF08A86",
+                            "Ref": "ProvidedVpcPublicSubnet1Subnet06076D59",
                           },
                           """,
                         ],
@@ -3741,7 +3421,7 @@ exports[`HordeWorker matrix — provided vpc and bucket matches the saved snapsh
                         [
                           """,
                           {
-                            "Ref": "ProvidedVpcPrivateSubnet2Subnet75D56B6B",
+                            "Ref": "ProvidedVpcPublicSubnet2SubnetF9F23F05",
                           },
                           """,
                         ],
@@ -3757,7 +3437,7 @@ exports[`HordeWorker matrix — provided vpc and bucket matches the saved snapsh
                   "GroupId",
                 ],
               },
-              "","assign_public_ip":"DISABLED","log_group":"",
+              "","assign_public_ip":"ENABLED","log_group":"",
               {
                 "Ref": "HordeLogGroup1EE05984",
               },
@@ -3854,7 +3534,7 @@ exports[`HordeWorker matrix — provided vpc and bucket matches the saved snapsh
             "ARTIFACTS_BUCKET": {
               "Ref": "ProvidedBucket8A3897F1",
             },
-            "ASSIGN_PUBLIC_IP": "DISABLED",
+            "ASSIGN_PUBLIC_IP": "ENABLED",
             "CLUSTER_ARN": {
               "Fn::GetAtt": [
                 "HordeClusterA7629518",
@@ -3879,10 +3559,10 @@ exports[`HordeWorker matrix — provided vpc and bucket matches the saved snapsh
                 ",",
                 [
                   {
-                    "Ref": "ProvidedVpcPrivateSubnet1Subnet6AF08A86",
+                    "Ref": "ProvidedVpcPublicSubnet1Subnet06076D59",
                   },
                   {
-                    "Ref": "ProvidedVpcPrivateSubnet2Subnet75D56B6B",
+                    "Ref": "ProvidedVpcPublicSubnet2SubnetF9F23F05",
                   },
                 ],
               ],
@@ -5576,7 +5256,7 @@ exports[`HordeWorker matrix — provided vpc matches the saved snapshot 1`] = `
                         [
                           """,
                           {
-                            "Ref": "ProvidedVpcPrivateSubnet1Subnet6AF08A86",
+                            "Ref": "ProvidedVpcPublicSubnet1Subnet06076D59",
                           },
                           """,
                         ],
@@ -5588,7 +5268,7 @@ exports[`HordeWorker matrix — provided vpc matches the saved snapshot 1`] = `
                         [
                           """,
                           {
-                            "Ref": "ProvidedVpcPrivateSubnet2Subnet75D56B6B",
+                            "Ref": "ProvidedVpcPublicSubnet2SubnetF9F23F05",
                           },
                           """,
                         ],
@@ -5604,7 +5284,7 @@ exports[`HordeWorker matrix — provided vpc matches the saved snapshot 1`] = `
                   "GroupId",
                 ],
               },
-              "","assign_public_ip":"DISABLED","log_group":"",
+              "","assign_public_ip":"ENABLED","log_group":"",
               {
                 "Ref": "HordeLogGroup1EE05984",
               },
@@ -5701,7 +5381,7 @@ exports[`HordeWorker matrix — provided vpc matches the saved snapshot 1`] = `
             "ARTIFACTS_BUCKET": {
               "Ref": "HordeArtifactsBucket1A7FD4A4",
             },
-            "ASSIGN_PUBLIC_IP": "DISABLED",
+            "ASSIGN_PUBLIC_IP": "ENABLED",
             "CLUSTER_ARN": {
               "Fn::GetAtt": [
                 "HordeClusterA7629518",
@@ -5726,10 +5406,10 @@ exports[`HordeWorker matrix — provided vpc matches the saved snapshot 1`] = `
                 ",",
                 [
                   {
-                    "Ref": "ProvidedVpcPrivateSubnet1Subnet6AF08A86",
+                    "Ref": "ProvidedVpcPublicSubnet1Subnet06076D59",
                   },
                   {
-                    "Ref": "ProvidedVpcPrivateSubnet2Subnet75D56B6B",
+                    "Ref": "ProvidedVpcPublicSubnet2SubnetF9F23F05",
                   },
                 ],
               ],

--- a/cdk/test/__snapshots__/horde-worker.test.ts.snap
+++ b/cdk/test/__snapshots__/horde-worker.test.ts.snap
@@ -451,7 +451,7 @@ exports[`HordeWorker (5fh.3 skeleton) matches the saved snapshot 1`] = `
                         [
                           """,
                           {
-                            "Ref": "HordeVpcprivateSubnet1Subnet50085241",
+                            "Ref": "HordeVpcpublicSubnet1Subnet246CEB9F",
                           },
                           """,
                         ],
@@ -463,7 +463,7 @@ exports[`HordeWorker (5fh.3 skeleton) matches the saved snapshot 1`] = `
                         [
                           """,
                           {
-                            "Ref": "HordeVpcprivateSubnet2Subnet9297B1D5",
+                            "Ref": "HordeVpcpublicSubnet2Subnet6A9C5AB6",
                           },
                           """,
                         ],
@@ -479,7 +479,7 @@ exports[`HordeWorker (5fh.3 skeleton) matches the saved snapshot 1`] = `
                   "GroupId",
                 ],
               },
-              "","assign_public_ip":"DISABLED","log_group":"",
+              "","assign_public_ip":"ENABLED","log_group":"",
               {
                 "Ref": "HordeLogGroup1EE05984",
               },
@@ -576,7 +576,7 @@ exports[`HordeWorker (5fh.3 skeleton) matches the saved snapshot 1`] = `
             "ARTIFACTS_BUCKET": {
               "Ref": "HordeArtifactsBucket1A7FD4A4",
             },
-            "ASSIGN_PUBLIC_IP": "DISABLED",
+            "ASSIGN_PUBLIC_IP": "ENABLED",
             "CLUSTER_ARN": {
               "Fn::GetAtt": [
                 "HordeClusterA7629518",
@@ -601,10 +601,10 @@ exports[`HordeWorker (5fh.3 skeleton) matches the saved snapshot 1`] = `
                 ",",
                 [
                   {
-                    "Ref": "HordeVpcprivateSubnet1Subnet50085241",
+                    "Ref": "HordeVpcpublicSubnet1Subnet246CEB9F",
                   },
                   {
-                    "Ref": "HordeVpcprivateSubnet2Subnet9297B1D5",
+                    "Ref": "HordeVpcpublicSubnet2Subnet6A9C5AB6",
                   },
                 ],
               ],
@@ -1494,130 +1494,6 @@ exports[`HordeWorker (5fh.3 skeleton) matches the saved snapshot 1`] = `
       },
       "Type": "AWS::EC2::VPCGatewayAttachment",
     },
-    "HordeVpcprivateSubnet1DefaultRoute184FFD8B": {
-      "Properties": {
-        "DestinationCidrBlock": "0.0.0.0/0",
-        "NatGatewayId": {
-          "Ref": "HordeVpcpublicSubnet1NATGateway73FD7C1D",
-        },
-        "RouteTableId": {
-          "Ref": "HordeVpcprivateSubnet1RouteTableE564B7A0",
-        },
-      },
-      "Type": "AWS::EC2::Route",
-    },
-    "HordeVpcprivateSubnet1RouteTableAssociationE29E1B5E": {
-      "Properties": {
-        "RouteTableId": {
-          "Ref": "HordeVpcprivateSubnet1RouteTableE564B7A0",
-        },
-        "SubnetId": {
-          "Ref": "HordeVpcprivateSubnet1Subnet50085241",
-        },
-      },
-      "Type": "AWS::EC2::SubnetRouteTableAssociation",
-    },
-    "HordeVpcprivateSubnet1RouteTableE564B7A0": {
-      "Properties": {
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "TestStack/Horde/Vpc/privateSubnet1",
-          },
-        ],
-        "VpcId": {
-          "Ref": "HordeVpcB5939D5D",
-        },
-      },
-      "Type": "AWS::EC2::RouteTable",
-    },
-    "HordeVpcprivateSubnet1Subnet50085241": {
-      "Properties": {
-        "AvailabilityZone": "dummy1a",
-        "CidrBlock": "10.0.2.0/24",
-        "MapPublicIpOnLaunch": false,
-        "Tags": [
-          {
-            "Key": "aws-cdk:subnet-name",
-            "Value": "private",
-          },
-          {
-            "Key": "aws-cdk:subnet-type",
-            "Value": "Private",
-          },
-          {
-            "Key": "Name",
-            "Value": "TestStack/Horde/Vpc/privateSubnet1",
-          },
-        ],
-        "VpcId": {
-          "Ref": "HordeVpcB5939D5D",
-        },
-      },
-      "Type": "AWS::EC2::Subnet",
-    },
-    "HordeVpcprivateSubnet2DefaultRoute791A061F": {
-      "Properties": {
-        "DestinationCidrBlock": "0.0.0.0/0",
-        "NatGatewayId": {
-          "Ref": "HordeVpcpublicSubnet1NATGateway73FD7C1D",
-        },
-        "RouteTableId": {
-          "Ref": "HordeVpcprivateSubnet2RouteTableB22C6503",
-        },
-      },
-      "Type": "AWS::EC2::Route",
-    },
-    "HordeVpcprivateSubnet2RouteTableAssociationAAC23162": {
-      "Properties": {
-        "RouteTableId": {
-          "Ref": "HordeVpcprivateSubnet2RouteTableB22C6503",
-        },
-        "SubnetId": {
-          "Ref": "HordeVpcprivateSubnet2Subnet9297B1D5",
-        },
-      },
-      "Type": "AWS::EC2::SubnetRouteTableAssociation",
-    },
-    "HordeVpcprivateSubnet2RouteTableB22C6503": {
-      "Properties": {
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "TestStack/Horde/Vpc/privateSubnet2",
-          },
-        ],
-        "VpcId": {
-          "Ref": "HordeVpcB5939D5D",
-        },
-      },
-      "Type": "AWS::EC2::RouteTable",
-    },
-    "HordeVpcprivateSubnet2Subnet9297B1D5": {
-      "Properties": {
-        "AvailabilityZone": "dummy1b",
-        "CidrBlock": "10.0.3.0/24",
-        "MapPublicIpOnLaunch": false,
-        "Tags": [
-          {
-            "Key": "aws-cdk:subnet-name",
-            "Value": "private",
-          },
-          {
-            "Key": "aws-cdk:subnet-type",
-            "Value": "Private",
-          },
-          {
-            "Key": "Name",
-            "Value": "TestStack/Horde/Vpc/privateSubnet2",
-          },
-        ],
-        "VpcId": {
-          "Ref": "HordeVpcB5939D5D",
-        },
-      },
-      "Type": "AWS::EC2::Subnet",
-    },
     "HordeVpcpublicSubnet1DefaultRoute071AE970": {
       "DependsOn": [
         "HordeVpcVPCGWAEEB195C",
@@ -1632,42 +1508,6 @@ exports[`HordeWorker (5fh.3 skeleton) matches the saved snapshot 1`] = `
         },
       },
       "Type": "AWS::EC2::Route",
-    },
-    "HordeVpcpublicSubnet1EIP9B0718C2": {
-      "Properties": {
-        "Domain": "vpc",
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "TestStack/Horde/Vpc/publicSubnet1",
-          },
-        ],
-      },
-      "Type": "AWS::EC2::EIP",
-    },
-    "HordeVpcpublicSubnet1NATGateway73FD7C1D": {
-      "DependsOn": [
-        "HordeVpcpublicSubnet1DefaultRoute071AE970",
-        "HordeVpcpublicSubnet1RouteTableAssociation962A9F88",
-      ],
-      "Properties": {
-        "AllocationId": {
-          "Fn::GetAtt": [
-            "HordeVpcpublicSubnet1EIP9B0718C2",
-            "AllocationId",
-          ],
-        },
-        "SubnetId": {
-          "Ref": "HordeVpcpublicSubnet1Subnet246CEB9F",
-        },
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "TestStack/Horde/Vpc/publicSubnet1",
-          },
-        ],
-      },
-      "Type": "AWS::EC2::NatGateway",
     },
     "HordeVpcpublicSubnet1RouteTableAssociation962A9F88": {
       "Properties": {

--- a/cdk/test/horde-worker-props.test.ts
+++ b/cdk/test/horde-worker-props.test.ts
@@ -1,4 +1,4 @@
-import type { HordeWorkerProps } from "../src";
+import type { HordeNetworkMode, HordeWorkerProps } from "../src";
 
 describe("HordeWorkerProps", () => {
   it("re-exports from index (compile-time check)", () => {
@@ -14,5 +14,11 @@ describe("HordeWorkerProps", () => {
       secrets: {} as never,
     };
     expect(_bad).toBeDefined();
+  });
+
+  it("accepts networkMode 'public' and 'private'", () => {
+    const a: HordeNetworkMode = "public";
+    const b: HordeNetworkMode = "private";
+    expect([a, b]).toEqual(["public", "private"]);
   });
 });

--- a/cdk/test/horde-worker.test.ts
+++ b/cdk/test/horde-worker.test.ts
@@ -3,6 +3,7 @@ import { Match, Template } from "aws-cdk-lib/assertions";
 import * as ecr from "aws-cdk-lib/aws-ecr";
 import * as ecs from "aws-cdk-lib/aws-ecs";
 import * as secretsmanager from "aws-cdk-lib/aws-secretsmanager";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
 import { HordeWorker } from "../src";
 
 function synth() {
@@ -342,7 +343,7 @@ describe("HordeWorker (5fh.3 skeleton)", () => {
     ]) {
       expect(valueStr).toContain(`\\"${key}\\"`);
     }
-    expect(valueStr).toContain('\\"DISABLED\\"');
+    expect(valueStr).toContain('\\"ENABLED\\"');
     expect(valueStr).toContain('\\"ecs\\"');
     expect(valueStr).toContain('\\"max_concurrent\\":5');
     expect(valueStr).toContain('\\"default_timeout_minutes\\":1440');
@@ -567,5 +568,113 @@ describe("HordeWorker status-sync (5fh.12/13/14)", () => {
       expect(a).not.toMatch(/^ssm:/);
       expect(a).not.toMatch(/^secretsmanager:/);
     }
+  });
+});
+
+function synthWithProps(extra: Record<string, unknown>): Template {
+  const app = new App();
+  const stack = new Stack(app, "TestStack", {
+    env: { account: "111111111111", region: "us-east-1" },
+  });
+  const repo = ecr.Repository.fromRepositoryName(stack, "Repo", "horde-test");
+  new HordeWorker(stack, "Horde", {
+    projectSlug: "test",
+    repo: "github.com/example/test",
+    workerImage: ecs.ContainerImage.fromRegistry("public.ecr.aws/horde/test:latest"),
+    ecrRepository: repo,
+    secrets: {
+      CLAUDE_CODE_OAUTH_TOKEN: secretsmanager.Secret.fromSecretNameV2(stack, "Claude", "horde/claude"),
+      GIT_TOKEN: secretsmanager.Secret.fromSecretNameV2(stack, "Git", "horde/git"),
+    },
+    ...extra,
+  });
+  return Template.fromStack(stack);
+}
+
+describe("HordeWorker networkMode", () => {
+  it("defaults to public: no NAT Gateway and assign_public_ip ENABLED", () => {
+    const t = synthWithProps({});
+    t.resourceCountIs("AWS::EC2::NatGateway", 0);
+    const params = t.findResources("AWS::SSM::Parameter");
+    const cfg = Object.values(params).find((p) => p.Properties.Name === "/horde/test/config");
+    if (!cfg) throw new Error("expected /horde/test/config parameter");
+    expect(JSON.stringify(cfg.Properties.Value)).toContain('\\"assign_public_ip\\":\\"');
+    expect(JSON.stringify(cfg.Properties.Value)).toContain('\\"ENABLED\\"');
+  });
+
+  it("public mode sets the drain Lambda ASSIGN_PUBLIC_IP env to ENABLED", () => {
+    const t = synthWithProps({});
+    t.hasResourceProperties("AWS::Lambda::Function", {
+      Environment: { Variables: Match.objectLike({ ASSIGN_PUBLIC_IP: "ENABLED" }) },
+    });
+  });
+
+  it("private mode creates one NAT Gateway and sets assign_public_ip DISABLED", () => {
+    const t = synthWithProps({ networkMode: "private" });
+    t.resourceCountIs("AWS::EC2::NatGateway", 1);
+    const params = t.findResources("AWS::SSM::Parameter");
+    const cfg = Object.values(params).find((p) => p.Properties.Name === "/horde/test/config");
+    if (!cfg) throw new Error("expected /horde/test/config parameter");
+    expect(JSON.stringify(cfg.Properties.Value)).toContain('\\"DISABLED\\"');
+  });
+
+  it("private mode sets the drain Lambda ASSIGN_PUBLIC_IP env to DISABLED", () => {
+    const t = synthWithProps({ networkMode: "private" });
+    t.hasResourceProperties("AWS::Lambda::Function", {
+      Environment: { Variables: Match.objectLike({ ASSIGN_PUBLIC_IP: "DISABLED" }) },
+    });
+  });
+
+  it("throws when a BYO VPC has no public subnets in public mode", () => {
+    const app = new App();
+    const stack = new Stack(app, "S", { env: { account: "111111111111", region: "us-east-1" } });
+    const repo = ecr.Repository.fromRepositoryName(stack, "Repo", "horde-test");
+    const vpc = new ec2.Vpc(stack, "PrivateOnlyVpc", {
+      maxAzs: 1,
+      natGateways: 0,
+      subnetConfiguration: [
+        { name: "isolated", subnetType: ec2.SubnetType.PRIVATE_ISOLATED, cidrMask: 24 },
+      ],
+    });
+    expect(() =>
+      new HordeWorker(stack, "Horde", {
+        projectSlug: "test",
+        repo: "github.com/example/test",
+        workerImage: ecs.ContainerImage.fromRegistry("public.ecr.aws/horde/test:latest"),
+        ecrRepository: repo,
+        vpc,
+        secrets: {
+          CLAUDE_CODE_OAUTH_TOKEN: secretsmanager.Secret.fromSecretNameV2(stack, "C", "c"),
+          GIT_TOKEN: secretsmanager.Secret.fromSecretNameV2(stack, "G", "g"),
+        },
+      }),
+    ).toThrow(/no .* subnet/i);
+  });
+
+  it("throws when a BYO VPC has no private-egress subnets in private mode", () => {
+    const app = new App();
+    const stack = new Stack(app, "S", { env: { account: "111111111111", region: "us-east-1" } });
+    const repo = ecr.Repository.fromRepositoryName(stack, "Repo", "horde-test");
+    const vpc = new ec2.Vpc(stack, "PublicOnlyVpc", {
+      maxAzs: 1,
+      natGateways: 0,
+      subnetConfiguration: [
+        { name: "public", subnetType: ec2.SubnetType.PUBLIC, cidrMask: 24 },
+      ],
+    });
+    expect(() =>
+      new HordeWorker(stack, "Horde", {
+        projectSlug: "test",
+        repo: "github.com/example/test",
+        workerImage: ecs.ContainerImage.fromRegistry("public.ecr.aws/horde/test:latest"),
+        ecrRepository: repo,
+        vpc,
+        networkMode: "private",
+        secrets: {
+          CLAUDE_CODE_OAUTH_TOKEN: secretsmanager.Secret.fromSecretNameV2(stack, "C", "c"),
+          GIT_TOKEN: secretsmanager.Secret.fromSecretNameV2(stack, "G", "g"),
+        },
+      }),
+    ).toThrow(/no .* subnet/i);
   });
 });

--- a/cdk/test/horde-worker.test.ts
+++ b/cdk/test/horde-worker.test.ts
@@ -648,7 +648,7 @@ describe("HordeWorker networkMode", () => {
           GIT_TOKEN: secretsmanager.Secret.fromSecretNameV2(stack, "G", "g"),
         },
       }),
-    ).toThrow(/no .* subnet/i);
+    ).toThrow(/networkMode '.*' requires ec2\.SubnetType\..* subnets in the VPC, but none were found/);
   });
 
   it("throws when a BYO VPC has no private-egress subnets in private mode", () => {
@@ -675,6 +675,6 @@ describe("HordeWorker networkMode", () => {
           GIT_TOKEN: secretsmanager.Secret.fromSecretNameV2(stack, "G", "g"),
         },
       }),
-    ).toThrow(/no .* subnet/i);
+    ).toThrow(/networkMode '.*' requires ec2\.SubnetType\..* subnets in the VPC, but none were found/);
   });
 });

--- a/docs/superpowers/plans/2026-06-12-networkmode-public-default.md
+++ b/docs/superpowers/plans/2026-06-12-networkmode-public-default.md
@@ -1,0 +1,503 @@
+# networkMode public-subnet default Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the `HordeWorker` CDK construct default to public-subnet + public-IP networking (no NAT Gateway, ~$32/mo saved), with a `networkMode: 'private'` lever that restores the NAT-bearing private posture.
+
+**Architecture:** CDK-only change. A single `networkMode?: 'public' | 'private'` prop (default `'public'`) drives three derived values inside the construct: the managed VPC's subnet configuration (NAT or no NAT), the subnet type selected for the task/drain network config, and the `assign_public_ip` string written to SSM and the drain Lambda env. The Go CLI, SSM JSON contract, drain Lambda code, and bootstrap CloudFormation template are all untouched — they already support `ENABLED`/public subnets.
+
+**Tech Stack:** TypeScript, AWS CDK (`aws-cdk-lib`), Jest with `aws-cdk-lib/assertions` (`Template`/`Match`) + snapshot tests. All commands run from the `cdk/` directory.
+
+**Working directory:** All paths below are relative to the repo root. All `npm` commands run from `cdk/`. The session's shell cwd is already `cdk/`.
+
+---
+
+## File Structure
+
+- **Modify** `cdk/src/horde-worker-props.ts` — add the `HordeNetworkMode` type alias and `networkMode?` prop with JSDoc.
+- **Modify** `cdk/src/index.ts` — re-export the `HordeNetworkMode` type.
+- **Modify** `cdk/src/horde-worker.ts` — resolve `networkMode`; branch the managed-VPC subnet config; make subnet selection + `assign_public_ip` mode-driven; thread the value into the SSM JSON and drain env; add the empty-subnet synth guard.
+- **Modify** `cdk/test/horde-worker.test.ts` — update the SSM-JSON assertion from `DISABLED` to `ENABLED`; add default-public assertions (no NAT, ENABLED) and explicit-private assertions (NAT present, DISABLED) and the two BYO-VPC error cases.
+- **Regenerate** `cdk/test/__snapshots__/horde-worker-matrix.test.ts.snap` — the default-networking change alters the matrix snapshots; regenerate with `jest -u`.
+- **Modify** `cdk/src/horde-worker-props.ts` JSDoc also updates the `vpc?` `@default` note (subnet layout now depends on mode).
+
+---
+
+### Task 1: Add the `networkMode` prop and type
+
+**Files:**
+- Modify: `cdk/src/horde-worker-props.ts`
+- Modify: `cdk/src/index.ts`
+- Test: `cdk/test/horde-worker-props.test.ts`
+
+- [ ] **Step 1: Write a failing compile-time test for the new type export**
+
+Append to `cdk/test/horde-worker-props.test.ts`, inside the existing `describe("HordeWorkerProps", ...)` block (before its closing `});`):
+
+```ts
+  it("accepts networkMode 'public' and 'private'", () => {
+    const a: HordeNetworkMode = "public";
+    const b: HordeNetworkMode = "private";
+    expect([a, b]).toEqual(["public", "private"]);
+  });
+```
+
+And change the top import line to also import the type:
+
+```ts
+import type { HordeNetworkMode, HordeWorkerProps } from "../src";
+```
+
+- [ ] **Step 2: Run the build to verify it fails**
+
+Run: `npm run build`
+Expected: FAIL — `tsc` error `Module '"../src"' has no exported member 'HordeNetworkMode'` (and the test references an undefined type).
+
+- [ ] **Step 3: Add the type alias and prop**
+
+In `cdk/src/horde-worker-props.ts`, add this exported type alias near the top of the file (after the existing imports, before the `HordeWorkerSecrets`/`HordeWorkerProps` declarations):
+
+```ts
+/** Network posture for worker tasks. See `HordeWorkerProps.networkMode`. */
+export type HordeNetworkMode = "public" | "private";
+```
+
+Then, in the `HordeWorkerProps` interface, immediately after the existing `vpc?` prop, add:
+
+```ts
+  /**
+   * Network posture for the worker tasks.
+   *
+   * - `'public'` (default): tasks run in PUBLIC subnets with a public IPv4
+   *   address and reach the internet directly via the Internet Gateway — no
+   *   NAT Gateway is created (~$32/mo saved). The worker security group has no
+   *   ingress rules, so the public IP enables egress only; nothing on the
+   *   internet can open a connection to the task.
+   * - `'private'`: tasks run in PRIVATE_WITH_EGRESS subnets with no public IP,
+   *   reaching the internet through a NAT Gateway the construct creates. Choose
+   *   this to limit the blast radius of a future ingress rule, or when workers
+   *   must reach private VPC resources without an internet path.
+   *
+   * With a bring-your-own `vpc`, this selects which of that VPC's subnets to
+   * use; a synth-time error is raised if the VPC has no subnets of the chosen
+   * type. The default is `'public'` in all cases — supplying a VPC does not
+   * change it.
+   *
+   * @default 'public'
+   */
+  readonly networkMode?: HordeNetworkMode;
+```
+
+Also update the existing `vpc?` prop's `@default` line so it reflects the mode-dependent layout. Change:
+
+```ts
+   * @default — a new VPC with 2 private + 2 public subnets is created.
+```
+
+to:
+
+```ts
+   * @default — a new VPC. In `networkMode: 'public'` (the default) it has only
+   *   public subnets and no NAT Gateway; in `'private'` it adds
+   *   PRIVATE_WITH_EGRESS subnets and one NAT Gateway.
+```
+
+- [ ] **Step 4: Re-export the type from the package index**
+
+In `cdk/src/index.ts`, change the props type re-export line:
+
+```ts
+export type { HordeWorkerProps, HordeWorkerSecrets } from "./horde-worker-props";
+```
+
+to:
+
+```ts
+export type { HordeNetworkMode, HordeWorkerProps, HordeWorkerSecrets } from "./horde-worker-props";
+```
+
+- [ ] **Step 5: Run the build to verify it passes**
+
+Run: `npm run build`
+Expected: PASS — `tsc` clean, both lambda bundles emitted.
+
+- [ ] **Step 6: Run the props test**
+
+Run: `npx jest test/horde-worker-props.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cdk/src/horde-worker-props.ts cdk/src/index.ts cdk/test/horde-worker-props.test.ts
+git commit -m "feat(cdk): add networkMode prop and HordeNetworkMode type"
+```
+
+---
+
+### Task 2: Make the managed VPC, subnet selection, and assign_public_ip mode-driven
+
+**Files:**
+- Modify: `cdk/src/horde-worker.ts:182-200` (managed VPC block)
+- Modify: `cdk/src/horde-worker.ts:382-384` (subnet selection)
+- Modify: `cdk/src/horde-worker.ts:408-433` (SSM config JSON — `assign_public_ip` + subnets var name)
+- Modify: `cdk/src/horde-worker.ts:564-574` (drain Lambda env)
+
+This task is wiring, validated by Task 3's tests. Implement it, then build.
+
+- [ ] **Step 1: Resolve `networkMode` once at the top of the constructor**
+
+In `cdk/src/horde-worker.ts`, find the early constructor lines (right after `const retention = toRetention(...)`, near line 178) and add:
+
+```ts
+    const networkMode = props.networkMode ?? "public";
+```
+
+- [ ] **Step 2: Branch the managed VPC subnet config on the mode**
+
+Replace the managed-VPC `else` block (lines 184-200):
+
+```ts
+    } else {
+      const vpc = new ec2.Vpc(this, "Vpc", {
+        maxAzs: 2,
+        natGateways: 1,
+        vpcName: `horde-${slug}-vpc`,
+        subnetConfiguration: [
+          { name: "public", subnetType: ec2.SubnetType.PUBLIC, cidrMask: 24 },
+          {
+            name: "private",
+            subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
+            cidrMask: 24,
+          },
+        ],
+      });
+      cdk.Tags.of(vpc).add("Name", `horde-${slug}-vpc`);
+      this.vpc = vpc;
+    }
+```
+
+with:
+
+```ts
+    } else {
+      const vpc = new ec2.Vpc(this, "Vpc", {
+        maxAzs: 2,
+        // 'public': no NAT, tasks egress directly via the IGW. 'private': one
+        // NAT Gateway fronting PRIVATE_WITH_EGRESS subnets.
+        natGateways: networkMode === "public" ? 0 : 1,
+        vpcName: `horde-${slug}-vpc`,
+        subnetConfiguration:
+          networkMode === "public"
+            ? [{ name: "public", subnetType: ec2.SubnetType.PUBLIC, cidrMask: 24 }]
+            : [
+                { name: "public", subnetType: ec2.SubnetType.PUBLIC, cidrMask: 24 },
+                {
+                  name: "private",
+                  subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
+                  cidrMask: 24,
+                },
+              ],
+      });
+      cdk.Tags.of(vpc).add("Name", `horde-${slug}-vpc`);
+      this.vpc = vpc;
+    }
+```
+
+- [ ] **Step 3: Make subnet selection mode-driven with an empty-selection guard**
+
+Replace the subnet-selection block (lines 382-384):
+
+```ts
+    const privateSubnetIds = this.vpc.selectSubnets({
+      subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
+    }).subnetIds;
+```
+
+with:
+
+```ts
+    const subnetType =
+      networkMode === "public"
+        ? ec2.SubnetType.PUBLIC
+        : ec2.SubnetType.PRIVATE_WITH_EGRESS;
+    const selectedSubnetIds = this.vpc.selectSubnets({ subnetType }).subnetIds;
+    if (selectedSubnetIds.length === 0) {
+      throw new Error(
+        `HordeWorker networkMode '${networkMode}' requires ${subnetType} subnets ` +
+          `in the VPC, but none were found.`,
+      );
+    }
+    const assignPublicIp = networkMode === "public" ? "ENABLED" : "DISABLED";
+```
+
+- [ ] **Step 4: Use the resolved subnets + assign_public_ip in the SSM config JSON**
+
+In the SSM config block (lines 408-433), the `subnetsJson` builder currently references `privateSubnetIds`. Change line ~410:
+
+```ts
+      cdk.Fn.join(",", privateSubnetIds.map((id) => cdk.Fn.join("", ['"', id, '"']))),
+```
+
+to:
+
+```ts
+      cdk.Fn.join(",", selectedSubnetIds.map((id) => cdk.Fn.join("", ['"', id, '"']))),
+```
+
+Then replace the hardcoded `assign_public_ip` literal segment (line ~422). Change:
+
+```ts
+      '","assign_public_ip":"DISABLED","log_group":"',
+```
+
+to (split so the resolved value is interpolated as its own segment):
+
+```ts
+      '","assign_public_ip":"',
+      assignPublicIp,
+      '","log_group":"',
+```
+
+- [ ] **Step 5: Use the resolved subnets + assign_public_ip in the drain Lambda env**
+
+In the `drainEnv` block (lines 564-574), change:
+
+```ts
+      SUBNETS: cdk.Fn.join(",", privateSubnetIds),
+      SECURITY_GROUP: this.workerSecurityGroup.securityGroupId,
+      ASSIGN_PUBLIC_IP: "DISABLED", // matches the SSM config above
+```
+
+to:
+
+```ts
+      SUBNETS: cdk.Fn.join(",", selectedSubnetIds),
+      SECURITY_GROUP: this.workerSecurityGroup.securityGroupId,
+      ASSIGN_PUBLIC_IP: assignPublicIp, // matches the SSM config above
+```
+
+- [ ] **Step 6: Build to verify there are no remaining references to `privateSubnetIds`**
+
+Run: `npm run build`
+Expected: PASS — `tsc` clean. If it fails with `Cannot find name 'privateSubnetIds'`, find the stray reference and switch it to `selectedSubnetIds`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cdk/src/horde-worker.ts
+git commit -m "feat(cdk): drive subnets/NAT/assign_public_ip from networkMode"
+```
+
+---
+
+### Task 3: Update and add construct tests
+
+**Files:**
+- Modify: `cdk/test/horde-worker.test.ts:345` (the `DISABLED` assertion)
+- Modify: `cdk/test/horde-worker.test.ts` (add a new `describe` block for networkMode)
+
+- [ ] **Step 1: Fix the now-wrong default assertion**
+
+In `cdk/test/horde-worker.test.ts`, the test `"SSM config JSON references every required HordeConfig field"` asserts the old default at line 345:
+
+```ts
+    expect(valueStr).toContain('\\"DISABLED\\"');
+```
+
+Change it to the new default:
+
+```ts
+    expect(valueStr).toContain('\\"ENABLED\\"');
+```
+
+- [ ] **Step 2: Run that test to verify the change is correct (it should now pass once Task 2 is in)**
+
+Run: `npx jest test/horde-worker.test.ts -t "references every required HordeConfig field"`
+Expected: PASS. (Before Task 2 it would have failed; this confirms Task 2 wired `ENABLED` into the default.)
+
+- [ ] **Step 3: Add the networkMode behavior tests**
+
+Append a new top-level `describe` block at the end of `cdk/test/horde-worker.test.ts` (after the final closing `});` of the existing describe). It reuses the imports already at the top of the file (`App`, `Stack`, `Match`, `Template`, `ecr`, `ecs`, `secretsmanager`) and adds `ec2`:
+
+```ts
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+
+function synthWithProps(extra: Record<string, unknown>): Template {
+  const app = new App();
+  const stack = new Stack(app, "TestStack", {
+    env: { account: "111111111111", region: "us-east-1" },
+  });
+  const repo = ecr.Repository.fromRepositoryName(stack, "Repo", "horde-test");
+  new HordeWorker(stack, "Horde", {
+    projectSlug: "test",
+    repo: "github.com/example/test",
+    workerImage: ecs.ContainerImage.fromRegistry("public.ecr.aws/horde/test:latest"),
+    ecrRepository: repo,
+    secrets: {
+      CLAUDE_CODE_OAUTH_TOKEN: secretsmanager.Secret.fromSecretNameV2(stack, "Claude", "horde/claude"),
+      GIT_TOKEN: secretsmanager.Secret.fromSecretNameV2(stack, "Git", "horde/git"),
+    },
+    ...extra,
+  });
+  return Template.fromStack(stack);
+}
+
+describe("HordeWorker networkMode", () => {
+  it("defaults to public: no NAT Gateway and assign_public_ip ENABLED", () => {
+    const t = synthWithProps({});
+    t.resourceCountIs("AWS::EC2::NatGateway", 0);
+    const params = t.findResources("AWS::SSM::Parameter");
+    const cfg = Object.values(params).find((p) => p.Properties.Name === "/horde/test/config");
+    if (!cfg) throw new Error("expected /horde/test/config parameter");
+    expect(JSON.stringify(cfg.Properties.Value)).toContain('\\"assign_public_ip\\":\\"');
+    expect(JSON.stringify(cfg.Properties.Value)).toContain('\\"ENABLED\\"');
+  });
+
+  it("public mode sets the drain Lambda ASSIGN_PUBLIC_IP env to ENABLED", () => {
+    const t = synthWithProps({});
+    t.hasResourceProperties("AWS::Lambda::Function", {
+      Environment: { Variables: Match.objectLike({ ASSIGN_PUBLIC_IP: "ENABLED" }) },
+    });
+  });
+
+  it("private mode creates one NAT Gateway and sets assign_public_ip DISABLED", () => {
+    const t = synthWithProps({ networkMode: "private" });
+    t.resourceCountIs("AWS::EC2::NatGateway", 1);
+    const params = t.findResources("AWS::SSM::Parameter");
+    const cfg = Object.values(params).find((p) => p.Properties.Name === "/horde/test/config");
+    if (!cfg) throw new Error("expected /horde/test/config parameter");
+    expect(JSON.stringify(cfg.Properties.Value)).toContain('\\"DISABLED\\"');
+  });
+
+  it("private mode sets the drain Lambda ASSIGN_PUBLIC_IP env to DISABLED", () => {
+    const t = synthWithProps({ networkMode: "private" });
+    t.hasResourceProperties("AWS::Lambda::Function", {
+      Environment: { Variables: Match.objectLike({ ASSIGN_PUBLIC_IP: "DISABLED" }) },
+    });
+  });
+
+  it("throws when a BYO VPC has no public subnets in public mode", () => {
+    const app = new App();
+    const stack = new Stack(app, "S", { env: { account: "111111111111", region: "us-east-1" } });
+    const repo = ecr.Repository.fromRepositoryName(stack, "Repo", "horde-test");
+    const vpc = new ec2.Vpc(stack, "PrivateOnlyVpc", {
+      maxAzs: 1,
+      natGateways: 0,
+      subnetConfiguration: [
+        { name: "isolated", subnetType: ec2.SubnetType.PRIVATE_ISOLATED, cidrMask: 24 },
+      ],
+    });
+    expect(() =>
+      new HordeWorker(stack, "Horde", {
+        projectSlug: "test",
+        repo: "github.com/example/test",
+        workerImage: ecs.ContainerImage.fromRegistry("public.ecr.aws/horde/test:latest"),
+        ecrRepository: repo,
+        vpc,
+        secrets: {
+          CLAUDE_CODE_OAUTH_TOKEN: secretsmanager.Secret.fromSecretNameV2(stack, "C", "c"),
+          GIT_TOKEN: secretsmanager.Secret.fromSecretNameV2(stack, "G", "g"),
+        },
+      }),
+    ).toThrow(/requires .* subnets in the VPC, but none were found/);
+  });
+
+  it("throws when a BYO VPC has no private-egress subnets in private mode", () => {
+    const app = new App();
+    const stack = new Stack(app, "S", { env: { account: "111111111111", region: "us-east-1" } });
+    const repo = ecr.Repository.fromRepositoryName(stack, "Repo", "horde-test");
+    const vpc = new ec2.Vpc(stack, "PublicOnlyVpc", {
+      maxAzs: 1,
+      natGateways: 0,
+      subnetConfiguration: [
+        { name: "public", subnetType: ec2.SubnetType.PUBLIC, cidrMask: 24 },
+      ],
+    });
+    expect(() =>
+      new HordeWorker(stack, "Horde", {
+        projectSlug: "test",
+        repo: "github.com/example/test",
+        workerImage: ecs.ContainerImage.fromRegistry("public.ecr.aws/horde/test:latest"),
+        ecrRepository: repo,
+        vpc,
+        networkMode: "private",
+        secrets: {
+          CLAUDE_CODE_OAUTH_TOKEN: secretsmanager.Secret.fromSecretNameV2(stack, "C", "c"),
+          GIT_TOKEN: secretsmanager.Secret.fromSecretNameV2(stack, "G", "g"),
+        },
+      }),
+    ).toThrow(/requires .* subnets in the VPC, but none were found/);
+  });
+});
+```
+
+Note: place the new `import * as ec2 ...` line with the other imports at the top of the file, not inside the describe block (shown above only to indicate it is needed). If `ec2` is already imported at the top, do not duplicate it.
+
+- [ ] **Step 4: Run the full networkMode + SSM test file**
+
+Run: `npx jest test/horde-worker.test.ts`
+Expected: PASS — all existing tests plus the 6 new networkMode tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cdk/test/horde-worker.test.ts
+git commit -m "test(cdk): cover networkMode public default and private lever"
+```
+
+---
+
+### Task 4: Regenerate matrix snapshots and run the full suite
+
+The matrix test (`cdk/test/horde-worker-matrix.test.ts`) uses `toMatchSnapshot()`. The default-networking change alters the synthesized template for the construct-owned-VPC cells, so the saved snapshots must be regenerated. The BYO-VPC matrix cells use CDK's default VPC (which has public subnets), so they still synth under the default `'public'` mode — only the snapshot content changes, no error.
+
+- [ ] **Step 1: Run the suite to see the snapshot mismatch (confirms the change is captured)**
+
+Run: `npx jest test/horde-worker-matrix.test.ts`
+Expected: FAIL — snapshot mismatches for the cells using the construct's own VPC (NAT Gateway removed, subnets changed). This is expected; do not "fix" by editing code.
+
+- [ ] **Step 2: Inspect what changed before blessing it**
+
+Run: `npx jest test/horde-worker-matrix.test.ts 2>&1 | grep -E "NatGateway|AssignPublicIp|SubnetType|- |\\+ " | head -40`
+Expected: the diff shows NAT Gateway / EIP resources removed and public-subnet routing in the default cells — i.e. exactly the intended change, nothing unrelated.
+
+- [ ] **Step 3: Regenerate the snapshots**
+
+Run: `npx jest test/horde-worker-matrix.test.ts -u`
+Expected: PASS — snapshots written/updated.
+
+- [ ] **Step 4: Run the ENTIRE CDK suite the way CI does**
+
+Run: `npm run build && npm test`
+Expected: PASS — all test files green (`horde-worker`, `horde-worker-matrix`, `horde-worker-events`, `horde-worker-props`, `horde-worker-sidecars`, `drain-lambda`, `status-lambda`). This is exactly what the CI `cdk-test` job runs.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cdk/test/__snapshots__/horde-worker-matrix.test.ts.snap
+git commit -m "test(cdk): regenerate matrix snapshots for public-default networking"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- New prop `networkMode?: 'public' | 'private'`, default `'public'` → Task 1.
+- `HordeNetworkMode` exported type → Task 1.
+- Managed VPC public-only (no NAT) in public mode; public+private+NAT in private → Task 2 Step 2.
+- Mode-driven subnet selection, same path for managed/BYO → Task 2 Step 3.
+- Empty-selection synth guard → Task 2 Step 3 + Task 3 Steps (two BYO error tests).
+- `assign_public_ip` derived and threaded into SSM JSON + drain env → Task 2 Steps 4-5.
+- BYO uniform rule, default public everywhere → Task 1 JSDoc + Task 3 error tests.
+- "What does not change" (Go/SSM/drain-code/CFN) → no tasks touch them; verified by exploration. ✓
+- Tests: default no-NAT/ENABLED, explicit private NAT/DISABLED, two BYO errors → Task 3. Snapshot regen → Task 4.
+- Migration/release note → documentation concern; surfaced to the user at PR time, not a code task. Flagged in the PR-body checklist below.
+
+**Placeholder scan:** No TBD/TODO/"handle edge cases". Every code step shows complete code. ✓
+
+**Type/name consistency:** `networkMode`, `HordeNetworkMode`, `selectedSubnetIds`, `subnetType`, `assignPublicIp` are used identically across Tasks 1-3. The old `privateSubnetIds` name is fully removed in Task 2 (Steps 3-5) and Step 6 builds to catch any stray reference. ✓
+
+**At PR time:** the PR body MUST call out the behavior change — existing consumers who re-synth without `networkMode` move from private+NAT to public+no-NAT; `cdk deploy` will destroy the NAT and reassign task networking. Anyone wanting the old posture sets `networkMode: 'private'`. This belongs in the release notes / changelog for the next `@horde.io/cdk` version bump.

--- a/docs/superpowers/specs/2026-06-12-networkmode-public-default-design.md
+++ b/docs/superpowers/specs/2026-06-12-networkmode-public-default-design.md
@@ -1,0 +1,165 @@
+# `networkMode`: public-subnet default with a private lever
+
+**Date:** 2026-06-12
+**Scope:** CDK construct only (`@horde.io/cdk`). No Go, SSM-contract, or bootstrap-CloudFormation changes.
+
+## Problem
+
+The `HordeWorker` CDK construct always provisions a NAT Gateway and runs worker
+tasks in `PRIVATE_WITH_EGRESS` subnets with no public IP. A NAT Gateway costs
+~$32/mo (us-east-1: $0.045/hr) plus data-processing charges — a recurring cost
+that, for horde's threat model, buys almost no security. The construct offers no
+lever to opt out, so teams who want the cheaper public-subnet posture must fork
+the construct or use a CloudFormation escape hatch.
+
+## Security rationale (why public-by-default is safe here)
+
+The danger of a public subnet is **inbound** reachability, and that is governed
+by the security group, not the subnet. horde's worker security group is created
+with `allowAllOutbound: false` and a **single egress rule** (443 outbound) and
+**zero ingress rules** (`horde-worker.ts:257-266`). A security group is
+default-deny inbound, so with no ingress rule nothing on the internet can open a
+connection to the task — the public IP is purely an **egress** enabler.
+
+A NAT Gateway does **not** restrict egress; it only translates it. A compromised
+worker (these run AI agents executing arbitrary repo code) can exfiltrate to any
+HTTPS endpoint with or without a NAT. So the NAT buys **zero** egress security
+over a public IP. The two postures have an identical egress threat model.
+
+What `private` still genuinely offers, and why we keep it as a lever:
+
+1. **Blast-radius containment for future mistakes.** With a public IP, the day
+   someone adds an ingress rule ("open 8080 to debug") they expose it to the
+   whole internet. In a private subnet the same mistake only exposes it inside
+   the VPC.
+2. **Reaching private VPC resources** (RDS, internal services, PrivateLink)
+   without an internet path, with a simpler "nothing is internet-facing" audit
+   story.
+
+Neither is a reason to make `private` the *default*; both are reasons to keep it
+*available*.
+
+## Design
+
+### New prop
+
+Add to `HordeWorkerProps` (`cdk/src/horde-worker-props.ts`):
+
+```ts
+export type HordeNetworkMode = 'public' | 'private';
+
+/**
+ * Network posture for the worker tasks.
+ *
+ * - `'public'` (default): tasks run in PUBLIC subnets with a public IPv4
+ *   address and reach the internet directly via the Internet Gateway — no
+ *   NAT Gateway is created (~$32/mo saved). The worker security group has no
+ *   ingress rules, so the public IP enables egress only; nothing on the
+ *   internet can open a connection to the task.
+ * - `'private'`: tasks run in PRIVATE_WITH_EGRESS subnets with no public IP,
+ *   reaching the internet through a NAT Gateway the construct creates. Choose
+ *   this to limit the blast radius of a future ingress rule, or when workers
+ *   must reach private VPC resources without an internet path.
+ *
+ * With a bring-your-own `vpc`, this selects which of that VPC's subnets to
+ * use; a synth-time error is raised if the VPC has no subnets of the chosen
+ * type.
+ *
+ * @default 'public'
+ */
+readonly networkMode?: HordeNetworkMode;
+```
+
+### Construct behavior (`cdk/src/horde-worker.ts`)
+
+Resolve once near the top of the constructor:
+
+```ts
+const networkMode = props.networkMode ?? 'public';
+```
+
+**Managed VPC** (the `else` branch, currently ~line 184) branches on mode:
+
+- `'public'`: `subnetConfiguration: [{ name: 'public', subnetType: PUBLIC, cidrMask: 24 }]`, `natGateways: 0`.
+- `'private'`: today's config — `public` + `PRIVATE_WITH_EGRESS`, `natGateways: 1`.
+
+**Subnet selection** (currently hardcoded `PRIVATE_WITH_EGRESS`, ~line 382)
+becomes mode-driven and is the *same path* for managed and BYO VPCs:
+
+```ts
+const subnetType =
+  networkMode === 'public'
+    ? ec2.SubnetType.PUBLIC
+    : ec2.SubnetType.PRIVATE_WITH_EGRESS;
+const selectedSubnetIds = this.vpc.selectSubnets({ subnetType }).subnetIds;
+if (selectedSubnetIds.length === 0) {
+  throw new Error(
+    `HordeWorker networkMode '${networkMode}' requires ${subnetType} subnets ` +
+    `in the VPC, but none were found.`,
+  );
+}
+```
+
+The empty-selection guard turns a BYO VPC that lacks the chosen subnet type into
+a clear **synth-time** error instead of a runtime `RunTask` failure.
+
+**`assign_public_ip`** derives from the same value:
+
+```ts
+const assignPublicIp = networkMode === 'public' ? 'ENABLED' : 'DISABLED';
+```
+
+threaded into **both** the SSM config JSON (replacing the hardcoded
+`"assign_public_ip":"DISABLED"`, ~line 422) and the drain Lambda env (replacing
+`ASSIGN_PUBLIC_IP: "DISABLED"`, ~line 572). Both derive from the one resolved
+value, so they cannot drift.
+
+Three derived values (subnet config, subnet selection, `assign_public_ip`) all
+flow from the single `networkMode` — the coupling the enum exists to enforce.
+
+### BYO-VPC rule (uniform, no context-dependent default)
+
+`networkMode` selects subnet type identically for managed and BYO VPCs. The
+default is `'public'` in **all** cases — supplying a VPC does **not** flip the
+default to `'private'`. A typical enterprise private VPC therefore needs one
+explicit line, `networkMode: 'private'`, and gets a clear synth error if omitted
+(no PUBLIC subnets found). Rationale: uniform mental model + default-to-lowest-
+cost everywhere; the construct never silently steers toward a NAT.
+
+### What does NOT change
+
+The entire runtime path already supports public networking:
+
+- `internal/config/ssm.go` — `AssignPublicIp` field + `ENABLED`/`DISABLED` validation.
+- `internal/provider/ecs.go` — maps the string to the AWS enum, sets it on the task's `NetworkConfiguration`.
+- `cdk/src/drain-lambda/index.ts` — already reads `ASSIGN_PUBLIC_IP` from env.
+
+The Python bootstrap CloudFormation template keeps its NAT, consistent with the
+CFN-is-being-retired / CDK-leads convention.
+
+## Testing
+
+In `cdk/src/horde-worker.test.ts` (and any affected unit tests):
+
+- **`'public'` (default, prop omitted):** template has **no** `AWS::EC2::NatGateway`; SSM config JSON contains `"assign_public_ip":"ENABLED"`; drain Lambda env `ASSIGN_PUBLIC_IP: "ENABLED"`; task subnets are the public ones.
+- **`'private'` (explicit):** NAT Gateway present; `"assign_public_ip":"DISABLED"`; private subnets selected — today's behavior still reachable.
+- **BYO VPC + `'public'` with no public subnets** → synth throws the clear error.
+- **BYO VPC + `'private'` with no private-egress subnets** → synth throws the clear error.
+- Existing assertions/snapshots that currently expect a NAT or `DISABLED` in the default case are updated to the new default.
+
+CI's `cdk-test` job (`cd cdk && npm ci && npm run build && npm test`) must stay green.
+
+## Migration / release note (behavior change)
+
+Existing CDK consumers who re-synth without setting `networkMode` move from
+private+NAT to public+no-NAT — a real infrastructure change (NAT destroyed,
+tasks get public IPs). This is the intended default flip but **must be flagged
+prominently in the release notes**: a `cdk deploy` after upgrade will tear down
+the NAT and reassign task networking. Teams who want the prior posture set
+`networkMode: 'private'`.
+
+## Out of scope
+
+- No change to the Go CLI, SSM JSON contract, or `internal/bootstrap` CFN template.
+- No third network mode (e.g. `'isolated'` / PrivateLink-only). The enum leaves
+  room for it as a non-breaking future addition, but it is not built here.

--- a/internal/docs/content.go
+++ b/internal/docs/content.go
@@ -1180,8 +1180,11 @@ What it provisions
 
 Same surface as 'horde bootstrap' (CloudFormation flavor):
 
-  - VPC with public + private subnets and one NAT gateway (or BYO via
-    the 'vpc' prop)
+  - VPC sized by 'networkMode' (default 'public'): public subnets and
+    NO NAT gateway, with tasks on a public IP reaching the internet via
+    the internet gateway (~$32/mo saved). 'networkMode: "private"' adds
+    PRIVATE_WITH_EGRESS subnets and one NAT gateway instead. BYO via the
+    'vpc' prop (networkMode then selects which of its subnets to use).
   - ECS Fargate cluster + Fargate task definition (1 vCPU / 4 GB by
     default; tunable via 'cpu' / 'memoryMiB' props)
   - DynamoDB horde-runs-<slug> table with 4 GSIs (by-repo, by-ticket,
@@ -1253,6 +1256,14 @@ Config defaults
   defaultTimeoutMinutes     1440 (24 h)
   logRetentionDays          30
   ssmParameterPath          /horde/<projectSlug>/config
+  networkMode               public (public subnets, no NAT, public IP;
+                            'private' for private subnets behind a NAT)
+
+The worker security group is egress-only either way (single 443 outbound,
+no ingress), so the public-mode public IP enables outbound only — nothing
+on the internet can open a connection to a task. Choose 'private' to keep
+tasks off public IPs (e.g. to reach private VPC resources, or to limit the
+blast radius of a future ingress rule).
 
 CDK vs. CloudFormation
 ----------------------
@@ -1311,9 +1322,10 @@ Backend selection via HORDE_E2E_ECS_BACKEND:
     cdk              CDK-deployed stack. Requires TestECSCDK_Bringup
                      to have populated /tmp/horde-cdk-e2e-state.json.
 
-Cost: this stack runs its own NAT Gateway (~$32/mo idle) since it can't
-share infrastructure with the bootstrap CF stack. Always tear down when
-you're done.
+Cost: in the default 'public' networkMode this stack has no NAT Gateway,
+so its idle cost is negligible; with 'networkMode: "private"' it runs its
+own NAT Gateway (~$32/mo idle) since it can't share infrastructure with the
+bootstrap CF stack. Always tear down when you're done.
 `
 
 const topicLabels = `Run Labels and List Filtering


### PR DESCRIPTION
## Summary

The `HordeWorker` CDK construct always provisioned a NAT Gateway and ran workers in private subnets, with no lever to opt out. A NAT Gateway costs ~\$32/mo (us-east-1, before data-processing) and — for horde's threat model — buys almost no security.

This adds a `networkMode?: 'public' | 'private'` prop (default **`'public'`**):

- **`'public'`** (new default): tasks run in PUBLIC subnets with a public IP and egress directly via the Internet Gateway. **No NAT Gateway is created.** The worker security group has zero ingress rules, so the public IP is egress-only — nothing on the internet can open a connection to the task.
- **`'private'`**: the previous posture — PRIVATE_WITH_EGRESS subnets behind one NAT Gateway, `assign_public_ip: DISABLED`.

CDK-only change. The Go CLI, the SSM JSON contract (`internal/config/ssm.go`), the ECS provider, the drain Lambda, and the bootstrap CloudFormation template are untouched — they already supported `assign_public_ip: ENABLED` and arbitrary subnets. The one resolved `assignPublicIp` value and the selected subnet IDs are each computed once and threaded into both the SSM config JSON and the drain Lambda env, so they can't drift.

With a bring-your-own `vpc`, `networkMode` selects which of that VPC's subnets to use (same rule, default `'public'` everywhere); a clear synth-time error fires if the VPC lacks subnets of the chosen type.

### Why public-by-default is safe here

A NAT Gateway does not restrict egress — it only translates it. A compromised worker can exfiltrate to any HTTPS endpoint with or without a NAT, so the two postures have an identical egress threat model. Inbound reachability is governed by the security group, and horde's worker SG is egress-only (single 443 rule, no ingress). `'private'` remains available for teams who want to (a) limit the blast radius of a *future* ingress rule, or (b) reach private VPC resources without an internet path.

## ⚠️ Behavior change (migration)

Existing CDK consumers who re-synth **without** setting `networkMode` move from private+NAT to public+no-NAT. A `cdk deploy` after upgrade will **destroy the NAT Gateway and reassign task networking** (tasks get public IPs). This also applies to consumers passing their own VPC that has both public and private subnets — tasks now default to its *public* subnets.

**To keep the prior posture, set `networkMode: 'private'`.** This warrants a release-note callout on the next `@horde.io/cdk` version bump.

## Test Plan

- [x] `cd cdk && npm run build && npm test` — green (7 suites, 113 tests, 5 snapshots)
- [x] New tests: default → 0 NAT Gateways + `ENABLED` in SSM JSON and drain env; `'private'` → 1 NAT Gateway + `DISABLED`; BYO VPC missing the required subnet type → synth throws a horde-specific error (both modes)
- [x] Matrix + in-file snapshots regenerated; diff verified to contain only NAT/EIP/private-subnet removal + `assign_public_ip` flip
- [ ] CI: `unit-test`, `integration-test`, `cdk-test` on the PR

Spec: `docs/superpowers/specs/2026-06-12-networkmode-public-default-design.md`
Plan: `docs/superpowers/plans/2026-06-12-networkmode-public-default.md`